### PR TITLE
remove old github pages deployment action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,34 +287,3 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           command: deploy
           wranglerVersion: "4"
-
-  deploy:
-    name: Deploy to GitHub Pages
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs:
-      - quality
-      - build
-      - browser
-      - catalog
-      - audit
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      id-token: write
-      pages: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - uses: actions/configure-pages@v5
-      - uses: actions/download-artifact@v4
-        with:
-          name: verified-dist
-          path: dist
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: dist
-      - id: deployment
-        uses: actions/deploy-pages@v4

--- a/docs/CLOUDFLARE_WORKERS_MIGRATION.md
+++ b/docs/CLOUDFLARE_WORKERS_MIGRATION.md
@@ -215,9 +215,9 @@ Reasons to defer:
 
 ## CI Changes
 
-Current GitHub Actions deploys the verified `dist/` artifact to GitHub Pages.
-The Cloudflare migration reuses that same verified artifact after the build job
-generates Cloudflare deploy files into `dist/`.
+GitHub Actions deploys the verified `dist/` artifact to Cloudflare Workers
+Static Assets after the build job generates Cloudflare deploy files into
+`dist/`.
 
 Recommended deploy job shape:
 
@@ -258,7 +258,7 @@ Required GitHub secrets:
 Cloudflare recommends a scoped API token with Workers edit permissions. Do not
 store this token in the repository.
 
-Recommended CI sequencing:
+Completed cutover sequence:
 
 1. Keep GitHub Pages deploy until Cloudflare preview deploy is verified.
 2. Add a Cloudflare deploy job gated to `main` that uses repository secrets and
@@ -315,16 +315,14 @@ Manual smoke tests after deploy:
 
 ## GitHub Pages Cleanup After Cutover
 
-After Cloudflare is the production host:
+Cloudflare is now the production host. The cleanup state is:
 
-- Remove GitHub Pages deploy steps from `.github/workflows/ci.yml`.
-- Remove Pages permissions: `id-token: write`, `pages: write`.
-- Remove `actions/configure-pages`, `actions/upload-pages-artifact`, and
-  `actions/deploy-pages`.
-- Revisit `site/public/CNAME`. It is needed for GitHub Pages, but not for
-  Workers. Serving it from Cloudflare is harmless but unnecessary; removing it
-  after DNS cutover is cleaner.
-- Update docs and package script descriptions from GitHub Pages to Cloudflare
+- GitHub Pages deploy steps are removed from `.github/workflows/ci.yml`.
+- Pages permissions `id-token: write` and `pages: write` are removed.
+- `actions/configure-pages`, `actions/upload-pages-artifact`, and
+  `actions/deploy-pages` are removed.
+- `site/public/CNAME` is intentionally retained as a harmless static file.
+- Docs and package script descriptions point deployment work at Cloudflare
   Workers.
 
 ## Recommended Migration Milestones
@@ -339,15 +337,15 @@ After Cloudflare is the production host:
 
 3. **CI preview deploy**
    Add a Cloudflare deploy job that consumes `verified-dist` and deploys only
-   from `main`. Keep GitHub Pages deploy during this milestone.
+   from `main`.
 
 4. **Smoke and DNS cutover**
    Deploy, smoke test Workers routes/redirects/404s, then point the custom
    domain at the Worker.
 
 5. **GitHub Pages removal**
-   Remove Pages deploy configuration and Pages-only files after Cloudflare has
-   served production successfully.
+   Remove Pages deploy configuration after Cloudflare has served production
+   successfully.
 
 ## Risks And Guardrails
 

--- a/tests/config/ci-workflow.test.ts
+++ b/tests/config/ci-workflow.test.ts
@@ -58,18 +58,17 @@ describe("CI workflow", () => {
     expect(lighthouse).toContain("bun run test:perf:built");
   });
 
-  test("deploys the verified artifact instead of rebuilding on main", async () => {
+  test("does not keep a GitHub Pages deploy job after Cloudflare cutover", async () => {
     const workflow = await readCiWorkflow();
-    const deploy = jobBlock(workflow, "deploy");
 
-    expect(deploy).toContain("actions/download-artifact@v4");
-    expect(deploy).toContain("name: verified-dist");
-    expect(deploy).toContain("path: dist");
-    expect(deploy).toContain("actions/upload-pages-artifact@v3");
-    expect(deploy).toContain("actions/deploy-pages@v4");
-    expect(deploy).not.toContain("bun run build");
-    expect(deploy).not.toContain("bun run verify");
-    expect(deploy).not.toContain("bun run validate:html");
+    expect(workflow).not.toContain("\n  deploy:\n");
+    expect(workflow).not.toContain("Deploy to GitHub Pages");
+    expect(workflow).not.toContain("actions/configure-pages");
+    expect(workflow).not.toContain("actions/upload-pages-artifact");
+    expect(workflow).not.toContain("actions/deploy-pages");
+    expect(workflow).not.toContain("id-token: write");
+    expect(workflow).not.toContain("pages: write");
+    expect(workflow).not.toContain("github-pages");
   });
 
   test("deploys the verified artifact to Cloudflare Workers on main", async () => {


### PR DESCRIPTION
remove old github pages deployment action. no longer needed after migration.