### PR TITLE
Metadata overhaul

### DIFF
--- a/AUTHOR_TUTORIAL.md
+++ b/AUTHOR_TUTORIAL.md
@@ -272,6 +272,8 @@ Notes:
 - `title` is the article title shown on the page.
 - `description` should be brief and useful.
 - `date` should use `YYYY-MM-DD`.
+- `updated` is optional. Use it only for substantive revisions after
+  publication, not typo fixes or formatting-only edits.
 - `author` should match an existing author display name or alias in
   `site/content/authors/`.
 - `tags` are optional, but useful.
@@ -671,6 +673,7 @@ Before asking for review:
 - New categories, if any, have a matching folder and JSON metadata file.
 - The filename slug is URL-safe.
 - The frontmatter has `title`, `description`, `date`, and `author`.
+- `updated`, if present, marks a real post-publication revision.
 - The `author` value matches an existing author profile or a maintainer has
   added the new author metadata.
 - Images live under `site/assets/`.

--- a/AUTHOR_TUTORIAL.md
+++ b/AUTHOR_TUTORIAL.md
@@ -280,9 +280,17 @@ Notes:
 - `image` and `imageAlt` are optional, but recommended when the article has a
   preview image.
 - Add `draft: true` if the article should not publish yet.
+- `semantic` is optional special metadata for pages that are clearly reviews,
+  events, videos, audio works, books, datasets, software projects, or FAQs. Most
+  articles do not need it.
 
 Do not add `slug`, `category`, or `topic` frontmatter. The slug comes from the
 filename. The category comes from the folder.
+
+If you use `semantic`, only include facts that are true and visible to readers.
+The site turns this into a small visible details block and machine-readable
+metadata. See `site/README.md` for examples, and ask a maintainer if you are
+unsure.
 
 If this is a new author, ask a maintainer before submitting. The maintainer may
 add a new file in `site/content/authors/<author-slug>.md` with the author's

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -560,3 +560,93 @@ they are useful context. Explicitly deferred work belongs in
 - [x] Update site-owner/author-facing docs where the refactor changed how
       homepage labels, discovery links, support/social/share settings, or
       content defaults should be understood.
+
+### Milestone 150: Metadata, Semantics, And Accessibility Audit
+
+- [x] Research authoritative metadata, structured-data, semantic HTML,
+      accessibility, social-preview, SEO, and machine-readability guidance for
+      the platform.
+- [x] Audit current source and built output across major route types for
+      missing or weak metadata, semantics, accessibility affordances, social
+      previews, SEO signals, and machine-readable data.
+- [x] Run a broad full-site axe sweep against the built preview, record the
+      difference between first-party template findings and third-party embed
+      iframe findings, and fold the results into the audit.
+- [x] Iterate the audit into a developer-ready handoff with implementation
+      order, non-goals, route metadata matrix, stable ID policy, acceptance
+      criteria, risks, and validation expectations.
+- [x] Write an actionable report with current-state findings, high-value
+      immediate fixes, forward-looking platform metadata opportunities,
+      frontmatter/config authoring recommendations, validation strategy, and
+      implementation milestones.
+      Documented in
+      `agent-docs/METADATA_SEMANTICS_ACCESSIBILITY_AUDIT.md`.
+
+### Milestone 151: Metadata Platform A-F Design Lock
+
+- [x] Re-read the metadata/semantics/accessibility audit and inspect current
+      SEO, site config, route, feed, sitemap, bibliography, and validation code.
+- [x] Finalize the implementation design for milestones A-F, including shared
+      metadata contracts, route policy, site identity, route structured data,
+      article/announcement enrichment, Scholar/bibliography metadata, and
+      validation tooling.
+- [x] Check the design for blockers, missing tests, route policy ambiguity,
+      visibility leaks, authoring complexity, and migration risk before
+      implementation begins.
+      Design lock: route policy and stable IDs live in a typed metadata helper;
+      `BaseLayout`/`SiteHead` render normalized head metadata and shared
+      site identity; page routes supply only route-specific kind/data and
+      structured-data nodes; article/announcement enrichment shares the
+      publishable-entry path where possible; build verification becomes the
+      blocking rendered-output guard.
+
+### Milestone 152: A - Metadata Contract
+
+- [x] Add the shared metadata domain, route metadata model, stable ID helpers,
+      robots policy, social image fallback policy, and sitemap/feed/content
+      index inclusion policy.
+- [x] Add focused tests for metadata normalization, route policy, visibility
+      behavior, and stable entity IDs.
+
+### Milestone 153: B - Site Identity And Head Metadata
+
+- [x] Extend site identity config/schema/docs for publisher identity, locale,
+      social handles, same-as links, theme color, and default social image.
+- [x] Update `SiteHead` to render complete route/social metadata and sitewide
+      `WebSite`/publisher JSON-LD from normalized metadata.
+- [x] Verify article and non-article social/head metadata output.
+
+### Milestone 154: C - Route Structured Data
+
+- [x] Add JSON-LD helpers for breadcrumbs, collection pages, item lists,
+      profile pages, and conservative bibliography/list metadata.
+- [x] Integrate route-family structured data across home, archives, authors,
+      categories, tags, collections, announcements, bibliography, and articles.
+- [x] Verify route JSON-LD parsing and visible-content alignment.
+
+### Milestone 155: D - Article And Announcement Enrichment
+
+- [x] Add article/announcement metadata enrichment including article Open Graph
+      tags, `inLanguage`, `isPartOf`, publisher references, tags/section, and
+      `mainEntityOfPage`.
+- [x] Add the explicit author-facing `updated` policy and emit modified-date
+      metadata only when present.
+- [x] Verify article and announcement output, including existing PDF/social
+      behavior.
+
+### Milestone 156: E - Scholar And Bibliography Metadata
+
+- [x] Add low-risk Scholar metadata fields and deterministic
+      `citation_reference` output where reliable.
+- [x] Add conservative bibliography structured data and fallback behavior for
+      articles with no references or malformed citation data.
+- [x] Verify Scholar and bibliography metadata tests.
+
+### Milestone 157: F - Metadata Validation Tooling
+
+- [x] Add built-output validation for route metadata, JSON-LD parsing, social
+      image coverage, robots/sitemap/feed/content-index alignment, and
+      parser-based image alt behavior.
+- [x] Add or update a first-party full-site accessibility scan with third-party
+      iframe reporting separated from blocking first-party failures.
+- [x] Update scripts/docs/package references as needed and run release checks.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -695,3 +695,28 @@ they are useful context. Explicitly deferred work belongs in
       remaining profile expansion opportunities, and validation expectations.
 - [x] Run focused metadata/schema/component tests and release checks, fix any
       issues, and record verification before marking G complete.
+
+### Milestone 162: Traffic Advice Static Policy
+
+- [x] Add `/.well-known/traffic-advice` as a Cloudflare-served static asset
+      that explicitly allows private prefetch proxy traffic for the public
+      static site.
+- [x] Add the required static asset headers so Cloudflare serves the endpoint
+      with the traffic-advice JSON MIME type.
+- [x] Verify the file is copied into the release build, the headers file is
+      present, and the release checks still pass.
+      Verified with `bun test tests/config/static-public-files.test.ts --reporter=dots`,
+      `bun --silent run test:config`, `bun run check:release`, and direct
+      inspection of `dist/.well-known/traffic-advice` and `dist/_headers`.
+
+### Milestone 163: Cloudflare Immutable Astro Asset Cache Policy
+
+- [x] Add a Cloudflare `_headers` rule that applies long-lived immutable
+      caching only to Astro fingerprinted `/_astro/*` assets.
+- [x] Verify the cache rule is covered by config tests and copied into the
+      release build.
+- [x] Update Cloudflare/static author docs to explain why `_astro` gets
+      immutable caching and why non-fingerprinted outputs stay revalidated.
+      Verified with `bun test tests/config/static-public-files.test.ts --reporter=dots`,
+      `bun --silent run test:config`, `bun run check:release`, `git diff --check`,
+      and direct inspection of `dist/_headers`.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -650,3 +650,48 @@ they are useful context. Explicitly deferred work belongs in
 - [x] Add or update a first-party full-site accessibility scan with third-party
       iframe reporting separated from blocking first-party failures.
 - [x] Update scripts/docs/package references as needed and run release checks.
+
+### Milestone 158: G - Typed Semantic Metadata Design Lock
+
+- [x] Move typed special-schema work from the metadata audit into an explicit
+      platform design: author-facing frontmatter, normalized data model,
+      visible-content parity, JSON-LD graph integration, validation strategy,
+      non-goals, and first implementation scope.
+- [x] Review the design for platform reuse beyond TPM, authoring simplicity,
+      SEO/schema truthfulness, accessibility, performance, and future admin-UI
+      compatibility.
+- [x] Break the locked design into implementation milestones with concrete
+      tests and stop conditions before editing code.
+
+### Milestone 159: G - Semantic Frontmatter And Normalization
+
+- [x] Add a strict optional `semantic` frontmatter contract for article-like
+      publishable entries, with discriminated profile kinds for common
+      platform use cases such as reviews, events, media, datasets, software,
+      books, and FAQ content.
+- [x] Add typed normalization helpers that convert validated frontmatter into
+      view-model and JSON-LD-ready data without exposing arbitrary JSON-LD to
+      authors.
+- [x] Verify valid and invalid semantic frontmatter cases with focused schema
+      and helper tests.
+
+### Milestone 160: G - Semantic JSON-LD And Visible Details
+
+- [x] Emit optional semantic JSON-LD nodes for article and announcement pages
+      only from validated semantic metadata, linked to the base article-like
+      page node without changing normal metadata for entries that omit the
+      field.
+- [x] Add a compact visible semantic-details component so emitted metadata is
+      represented on the page and stays truthful to visible content.
+- [x] Verify article/announcement component output and JSON-LD parsing for
+      representative semantic profiles.
+
+### Milestone 161: G - Semantic Metadata Docs And Release Verification
+
+- [x] Update author/site-owner docs with practical guidance for using
+      `semantic`, including when not to use it and which fields become visible
+      page facts.
+- [x] Update developer-facing metadata audit notes with what was implemented,
+      remaining profile expansion opportunities, and validation expectations.
+- [x] Run focused metadata/schema/component tests and release checks, fix any
+      issues, and record verification before marking G complete.

--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -89,3 +89,26 @@ compatibility becomes a repeated blocker.
 - [ ] Replace the Chrome-based generator only after the new pipeline passes the
       release gates and produces better scholarly PDFs for the representative
       article set.
+
+## AI-Friendly Content Surfaces
+
+Reason deferred: public machine-readable indexes, route/entity manifests, and
+possible `llms.txt` support are valuable platform work, but they should wait
+until the typed metadata, structured-data, and route identity model is stable
+enough to expose as a durable public contract.
+
+Resume trigger: resume when admin UI work, public content APIs, agent/tool
+integrations, `llms.txt`, or external machine-readable content indexing becomes
+an active platform goal.
+
+- [ ] Define stable entity `@id` policy for site, publisher, authors, articles,
+      announcements, collections, categories, tags, and bibliography sources.
+- [ ] Add a public content index endpoint for route discovery and article
+      metadata, generated from canonical content data and route helpers.
+- [ ] Add a route/entity manifest for platform tooling and future admin UI
+      work.
+- [ ] Decide whether to add `llms.txt`, including what it promises and how it
+      remains current.
+- [ ] Add endpoint schema tests, built-output checks for stable IDs and
+      canonical URLs, and visibility/robots leak checks before publishing
+      machine-readable indexes.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ The public Astro URL will be:
 Use `draft: true` to keep an article unpublished. Draft articles are excluded
 from generated article routes, archives, categories, RSS, sitemap, and search.
 
+Use `updated: YYYY-MM-DD` only for substantive revisions that should appear in
+machine-readable article metadata. Do not change it for typo-only or
+formatting-only edits.
+
 If an article introduces a new author, add or request a matching author profile
 under `site/content/authors/<author-slug>.md`. Keep author metadata factual:
 display name, type, aliases, and explicitly approved public links only.
@@ -195,6 +199,11 @@ from the filename. The category comes from the source folder.
 
 `legacyPermalink` and `legacyBanner` may exist on older articles as inert
 historical metadata. They do not control routing, publishing, or rendering.
+
+Sitewide identity metadata lives in `site/config/site.json`. The identity block
+owns language, locale, publisher type, logo, theme color, and official social
+profiles used by Open Graph, Twitter cards, Schema.org JSON-LD, and sitemap
+verification.
 
 ## Category Folders
 

--- a/agent-docs/COMPONENT_REFACTOR_AUDIT.md
+++ b/agent-docs/COMPONENT_REFACTOR_AUDIT.md
@@ -1367,8 +1367,8 @@ components that are intentionally global.
   split out of the monolithic catalog component.
 - Milestone L is implemented for this pass: default config values have moved
   into `site-config-defaults`, preserving the public parser/export API. The
-  remaining release requirement is documentation and generated-schema
-  verification.
+  documentation, schema-related checks, platform-boundary checks, and release
+  verification have been completed for this pass.
 - Milestone M is implemented for this pass with code-backed decisions: TOC and
   header already have stable child boundaries, article images gained
   `ArticleImageFrame`, carousel controls gained a dedicated child component,
@@ -1825,14 +1825,29 @@ These are not blockers, but the next developer should keep them visible:
   components. Avoid making every primitive read `siteConfig`; that would reduce
   immediate prop plumbing but make future platform extraction harder.
 
-## Recommended Next Step
+## Completion State For This Refactor Pass
 
-Finish with documentation and verification:
+The active refactor pass is complete:
 
-1. Audit developer and site-owner docs for drift from the new primitives,
-   catalog lifecycle metadata, route view models, and config-default boundary.
-2. Regenerate/check the site config schema.
-3. Run the release gate.
-4. Treat additional catalog section splits and risky-system subcomponent
-   extraction as future incremental maintenance unless a concrete product or
-   test gap appears.
+- The second-pass milestones G-M have all been implemented or explicitly
+  scoped as incremental future maintenance.
+- Developer-facing and site-owner/author-facing documentation has been audited
+  and updated for the new primitives, config-default boundary, and catalog
+  lifecycle metadata.
+- `bun run check:release` passes after the refactor fixes discovered during
+  the release gate.
+
+Remaining items are not blockers for this refactor pass. They are future
+platformization opportunities or intentionally deferred feature work:
+
+- continue splitting the catalog into smaller sections when touching those
+  areas;
+- add a separate fixture-site configuration if/when platform reuse work needs
+  stronger proof;
+- evolve the homepage recipe from typed view model to configurable block recipe
+  only after the current explicit composition stops being enough;
+- revisit deferred PDF pipeline, citation locator, visible appendix, and asset
+  inlining work when their resume triggers fire.
+- treat additional catalog section splits and risky-system subcomponent
+  extraction as future incremental maintenance unless a concrete product or
+  test gap appears.

--- a/agent-docs/METADATA_SEMANTICS_ACCESSIBILITY_AUDIT.md
+++ b/agent-docs/METADATA_SEMANTICS_ACCESSIBILITY_AUDIT.md
@@ -143,19 +143,19 @@ using the shared metadata contract.
 
 ### Route Metadata Matrix
 
-| Route family | Robots | Social image | Structured data | Notes |
-| --- | --- | --- | --- | --- |
-| Home | `index,follow` | Site default or configured home image | `WebPage`, site `WebSite`, publisher, visible `ItemList` blocks where practical | Main first impression; complete social object is required. |
-| Article | `index,follow` unless content visibility says otherwise | Generated article social JPG with fallback | `BlogPosting` or `Article`, `WebPage`, publisher, optional citation metadata | Scholar meta and PDF link stay article-specific. |
-| Announcement | `index,follow` unless visibility says otherwise | Announcement image or default social image | `BlogPosting` or `Article`, `WebPage`, publisher | No Scholar metadata by default. |
-| Articles/archive | `index,follow` | Default social image | `CollectionPage`, `ItemList`, breadcrumbs where useful | Emit visible entries, not necessarily every historical item if paginated later. |
-| Category/tag/collection page | `index,follow` | Default social image | `CollectionPage`, `ItemList`, breadcrumbs | ItemList should match visible article list. |
-| Author index | `index,follow` | Default social image | `CollectionPage`, `ItemList` | List authors or author pages represented visibly. |
-| Author detail | `index,follow` | Author image or default social image | `ProfilePage`, `Person` or `Organization`, article `ItemList` | Anonymous/collective authors need explicit type handling. |
-| Bibliography | `index,follow` | Default social image | `CollectionPage`, `ItemList`, conservative source entries | Use `CreativeWork` only until source typing improves. |
-| Search | `noindex,follow` by default | Default social image | Plain `WebPage` only | Static search landing page is useful to users, but not a search-result page. |
-| 404 | `noindex,follow` | Default social image optional | Plain `WebPage` only | Keep accessible navigation, no fake structured data. |
-| Legacy redirect | `noindex,follow` | None required | None required | Canonical + meta refresh + fallback link are the contract. |
+| Route family                 | Robots                                                  | Social image                               | Structured data                                                                 | Notes                                                                           |
+| ---------------------------- | ------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Home                         | `index,follow`                                          | Site default or configured home image      | `WebPage`, site `WebSite`, publisher, visible `ItemList` blocks where practical | Main first impression; complete social object is required.                      |
+| Article                      | `index,follow` unless content visibility says otherwise | Generated article social JPG with fallback | `BlogPosting` or `Article`, `WebPage`, publisher, optional citation metadata    | Scholar meta and PDF link stay article-specific.                                |
+| Announcement                 | `index,follow` unless visibility says otherwise         | Announcement image or default social image | `BlogPosting` or `Article`, `WebPage`, publisher                                | No Scholar metadata by default.                                                 |
+| Articles/archive             | `index,follow`                                          | Default social image                       | `CollectionPage`, `ItemList`, breadcrumbs where useful                          | Emit visible entries, not necessarily every historical item if paginated later. |
+| Category/tag/collection page | `index,follow`                                          | Default social image                       | `CollectionPage`, `ItemList`, breadcrumbs                                       | ItemList should match visible article list.                                     |
+| Author index                 | `index,follow`                                          | Default social image                       | `CollectionPage`, `ItemList`                                                    | List authors or author pages represented visibly.                               |
+| Author detail                | `index,follow`                                          | Author image or default social image       | `ProfilePage`, `Person` or `Organization`, article `ItemList`                   | Anonymous/collective authors need explicit type handling.                       |
+| Bibliography                 | `index,follow`                                          | Default social image                       | `CollectionPage`, `ItemList`, conservative source entries                       | Use `CreativeWork` only until source typing improves.                           |
+| Search                       | `noindex,follow` by default                             | Default social image                       | Plain `WebPage` only                                                            | Static search landing page is useful to users, but not a search-result page.    |
+| 404                          | `noindex,follow`                                        | Default social image optional              | Plain `WebPage` only                                                            | Keep accessible navigation, no fake structured data.                            |
+| Legacy redirect              | `noindex,follow`                                        | None required                              | None required                                                                   | Canonical + meta refresh + fallback link are the contract.                      |
 
 ### Stable Entity ID Policy
 

--- a/agent-docs/METADATA_SEMANTICS_ACCESSIBILITY_AUDIT.md
+++ b/agent-docs/METADATA_SEMANTICS_ACCESSIBILITY_AUDIT.md
@@ -702,13 +702,18 @@ Add validation that covers source models and built output:
 Some articles may benefit from extra schema. This is now a planned platform
 capability, but it must be opt-in, typed, validated, and truthful.
 
-Potential frontmatter shape:
+This is a platform feature, not a TPM-only SEO enhancement. The author-facing
+interface should help different site owners describe richer page intent without
+learning JSON-LD or Schema.org internals, while keeping invalid and misleading
+metadata hard to publish.
+
+Target frontmatter shape:
 
 ```yaml
-schema:
+semantic:
   kind: review
   item:
-    type: VideoGame
+    type: video
     name: Undertale
     url: https://undertale.com/
   rating:
@@ -716,15 +721,87 @@ schema:
     best: 10
 ```
 
-Other future kinds:
+Design principles:
 
-- `video` for pages centered on a video.
-- `audio` for podcast/music/audio pages.
-- `book` for book reviews or book announcements.
-- `event` for real events.
-- `dataset` for published data.
-- `software` for software/project writeups.
+- Keep base route identity separate from the semantic profile. An article page
+  remains `BlogPosting`/`Article`; a review, event, dataset, video, or software
+  profile adds a related `Review`, `Event`, `Dataset`, `VideoObject`, or
+  `SoftwareApplication` node rather than pretending the page itself is that
+  object.
+- Use the same normalized semantic data for visible page details and JSON-LD.
+  This keeps structured data aligned with what readers can see.
+- Model semantic frontmatter as a discriminated union. Do not expose arbitrary
+  JSON-LD as the normal authoring interface.
+- Prefer a complete, tested subset of each kind over a broad, loose field bag.
+- Allow platform users with different editorial goals to use the feature
+  without TPM-specific assumptions.
+
+Initial supported kinds should cover the common platform cases:
+
+- `review` for qualitative or rated reviews of a book, article, video, audio,
+  software project, dataset, event, or other creative work.
+- `event` for pages or announcements centered on a real event with visible
+  date/time and location/online attendance data.
+- `video` for pages centered on a visible video.
+- `audio` for pages centered on a visible audio work or embed.
+- `book` for pages centered on a book, especially book announcements or
+  reviewable works.
+- `dataset` for published datasets, corpora, downloadable research material,
+  or data-driven project pages.
+- `software` for software/project release pages.
 - `faq` only for pages with visible question/answer content.
+
+First implementation scope:
+
+- Add the `semantic` field to article-like publishable content.
+- Add strict Zod schemas and TypeScript types for the supported profile kinds.
+- Add pure normalization and JSON-LD builder helpers.
+- Add a compact visible details component that renders only useful facts.
+- Integrate article and announcement JSON-LD with optional semantic nodes.
+- Document the authoring rules in `site/README.md`.
+
+Non-goals for the first implementation:
+
+- Do not add raw arbitrary JSON-LD frontmatter.
+- Do not add schema kinds without a typed contract and tests.
+- Do not infer semantic profiles from prose, embeds, filenames, or categories.
+- Do not emit hidden structured data that is not represented in visible page
+  content.
+- Do not chase every Google rich-result property on day one; use complete
+  enough Schema.org nodes and document which extra fields improve eligibility.
+
+Validation expectations:
+
+- Content schema tests for valid and invalid profile frontmatter.
+- Helper tests for normalized details and JSON-LD output.
+- Component tests proving visible details render useful facts and omit empty
+  fields.
+- Article and announcement JSON-LD tests proving semantic nodes are included
+  only when frontmatter opts in.
+- Release validation continues to parse emitted JSON-LD.
+
+Implemented platform shape:
+
+- `src/lib/semantic-metadata.ts` owns the typed `semantic` schema, visible
+  details view model, and JSON-LD node builder.
+- `src/lib/content-schemas.ts` exposes `semantic` on article-like publishable
+  entries while preserving strict frontmatter validation.
+- `ArticleJsonLd` and `AnnouncementJsonLd` keep normal `BlogPosting` output for
+  ordinary entries and switch to a graph only when semantic nodes are present.
+- `SemanticDetails` renders the reader-visible facts in the article opening so
+  optional structured data does not become hidden metadata.
+- The first implementation supports `review`, `event`, `video`, `audio`,
+  `book`, `dataset`, `software`, and `faq` profiles.
+- Build verification recognizes `BlogPosting` nodes inside JSON-LD graphs, so
+  social-image and article-metadata checks continue to cover semantic pages.
+
+Future expansion opportunities:
+
+- More item subtypes for reviews.
+- More rich-result fields where there is real visible source data.
+- Site-config defaults for labels and profile availability.
+- Advanced raw JSON-LD escape hatch only after typed profiles are stable and
+  only for technical maintainers, not as the primary authoring model.
 
 Do not add generic freeform JSON-LD frontmatter as the primary interface. It is
 too easy for non-technical authors to create invalid or misleading data. Prefer

--- a/agent-docs/METADATA_SEMANTICS_ACCESSIBILITY_AUDIT.md
+++ b/agent-docs/METADATA_SEMANTICS_ACCESSIBILITY_AUDIT.md
@@ -1,0 +1,1241 @@
+# Metadata, Semantics, And Accessibility Audit
+
+Date: 2026-05-16
+
+## Scope
+
+This report audits the platform for metadata, semantic HTML, accessibility,
+social previews, SEO, AI-agent accessibility, and machine readability. It is
+both a current-state audit and a research summary for future platform work.
+
+The audit reviewed:
+
+- Source metadata components and helpers in `src/components/seo/`, `src/lib/`,
+  `src/layouts/`, and route files under `src/pages/`.
+- Content schemas and site-owner configuration in `src/content.config.ts`,
+  `src/lib/content-schemas.ts`, `src/lib/site-config*`, and
+  `site/config/site.json`.
+- Representative generated output in `dist/`, plus a generated-output scan of
+  all 295 built HTML files.
+- A one-off full-site axe sweep of the built preview: 234 non-redirect routes
+  scanned, 61 redirect documents skipped.
+- Existing tests around SEO, Scholar metadata, social images, build
+  verification, article layouts, accessibility, and route behavior.
+- Authoritative guidance from Google Search Central, Google Scholar, W3C WAI,
+  the Open Graph protocol, and Schema.org.
+
+This report does not implement product changes. It scopes the highest-value
+metadata and semantic platform work so later implementation can be explicit,
+truthful, validated, and low-maintenance.
+
+## Executive Summary
+
+The site has a good baseline:
+
+- Every real route type inspected uses `BaseLayout`, `SiteHead`, a canonical
+  URL, title, description, RSS alternate link, language, viewport, and a real
+  `<main id="content">` target for skip links.
+- Article pages render semantic article structure, author/date metadata, article
+  JSON-LD, Scholar citation meta tags, social-preview images, optimized article
+  images, and PDF links where enabled.
+- Feed, sitemap, robots, icons, canonical redirects, article image alt text, and
+  social image generation have all had meaningful recent cleanup.
+- Content is already validated through Astro content collections and Zod
+  schemas, which is the right foundation for metadata correctness.
+
+The largest gaps are systematic rather than catastrophic:
+
+- Structured data is almost entirely limited to article `BlogPosting` JSON-LD.
+  The home page, author pages, category pages, tag pages, collection pages,
+  bibliography, search, and index pages do not yet expose page/list/profile/site
+  structured data.
+- Article JSON-LD is useful but minimal. It can be enriched with language,
+  publisher identity, site relationship, `dateModified` when truthful,
+  `mainEntityOfPage` as a `WebPage`, and staged citation data.
+- Most non-article pages do not receive a default social-preview image, so many
+  shareable pages degrade to `twitter:card=summary` and no `og:image`.
+- Site identity config is too thin for a reusable blogging platform. It should
+  support logo, same-as social URLs, default social image, locale, theme color,
+  organization/person identity, and optional contact/profile fields.
+- There is no metadata route contract or built-output metadata matrix test, so
+  drift can return quietly when new route types are added.
+- We should add a careful frontmatter path for optional special schemas, such as
+  reviews, videos, audio, events, datasets, books, and software, but only when
+  the visible page content actually supports that markup.
+
+The recommended immediate path is to add typed metadata primitives, route-level
+metadata contracts, sitewide structured data, default social image fallbacks,
+list/profile structured data, richer article metadata, and validation tests.
+
+## Roadmap Decisions
+
+After review, these items are in scope for the metadata/semantics/accessibility
+roadmap. They should be designed and implemented after the core metadata
+contract is in place:
+
+- Optional typed special-schema frontmatter for common cases such as reviews,
+  videos, audio posts, books, events, datasets, software writeups, and FAQs.
+  This should be a narrow validated author interface, not arbitrary JSON-LD.
+- Richer bibliography and citation metadata, starting with conservative
+  `citation_reference` strings and bibliography collection/list metadata.
+  Source-type-specific JSON-LD should wait until citation source typing is
+  reliable.
+- A truthful modified-date policy. Authors may provide an explicit `updated` or
+  equivalent field; the platform should emit `dateModified`,
+  `article:modified_time`, and related structured data only when that field is
+  present. Do not infer modified dates from git history or file mtimes.
+- AI-friendly content surfaces generated from canonical content data, such as a
+  route/entity manifest, a public content index, stable `@id` values, and
+  optional `llms.txt` after we define a clear contract for it.
+- Parser-based image-alt validation that distinguishes missing alt text,
+  intentionally empty decorative alt text, and meaningful content-image alt
+  text.
+- A documented manual validation workflow for major metadata changes, including
+  Google Rich Results Test, Schema.org validator, Lighthouse, browser
+  accessibility inspection, and social-preview validators where useful.
+
+One item remains deferred:
+
+- Embed accessibility strategy. The broad axe sweep found only third-party
+  iframe internals from YouTube and SoundCloud, not first-party template
+  failures. Keep provider issues visible, but revisit click-to-load embeds,
+  transcripts, captions, and lightweight fallbacks as a separate embed UX
+  project.
+
+## Implementation Handoff Summary
+
+### Core Goal
+
+Make metadata, structured data, semantic guarantees, and accessibility checks a
+typed platform layer instead of route-by-route incidental markup. A developer
+should be able to add a new route or content type and get correct canonical
+metadata, social previews, JSON-LD, robots behavior, and validation failures by
+using the shared metadata contract.
+
+### Non-Goals
+
+- Do not change public URLs.
+- Do not add SSR, middleware, request-time metadata, or client-only metadata.
+- Do not add arbitrary JSON-LD frontmatter as the main authoring interface.
+- Do not emit review, event, FAQ, or source-type schema unless the visible page
+  content and validated source data support it.
+- Do not infer modified dates from git history, file mtimes, build time, or
+  migration metadata.
+- Do not fail first-party accessibility gates on third-party iframe internals
+  that the site cannot control.
+
+### Architectural Conclusions
+
+- Add a metadata domain under `src/lib/metadata/` or an equivalent namespace.
+  It should own route metadata types, default normalization, JSON-LD builders,
+  social-image normalization, robots policy, sitemap inclusion policy, and
+  validation helpers.
+- Keep `SiteHead` as a renderer over a normalized metadata model. It should not
+  know how articles, authors, tags, or collections are loaded.
+- Keep route files thin: load content, call the appropriate metadata builder,
+  pass the normalized model to layout/head components, and render blocks.
+- Build JSON-LD with pure helpers that return serializable objects. Tests should
+  exercise helpers without rendering full pages.
+- Validate new author-facing fields at the content schema boundary, not inside
+  visual components.
+- Built-output checks should parse generated HTML and JSON-LD, not rely on
+  regexes.
+
+### Route Metadata Matrix
+
+| Route family | Robots | Social image | Structured data | Notes |
+| --- | --- | --- | --- | --- |
+| Home | `index,follow` | Site default or configured home image | `WebPage`, site `WebSite`, publisher, visible `ItemList` blocks where practical | Main first impression; complete social object is required. |
+| Article | `index,follow` unless content visibility says otherwise | Generated article social JPG with fallback | `BlogPosting` or `Article`, `WebPage`, publisher, optional citation metadata | Scholar meta and PDF link stay article-specific. |
+| Announcement | `index,follow` unless visibility says otherwise | Announcement image or default social image | `BlogPosting` or `Article`, `WebPage`, publisher | No Scholar metadata by default. |
+| Articles/archive | `index,follow` | Default social image | `CollectionPage`, `ItemList`, breadcrumbs where useful | Emit visible entries, not necessarily every historical item if paginated later. |
+| Category/tag/collection page | `index,follow` | Default social image | `CollectionPage`, `ItemList`, breadcrumbs | ItemList should match visible article list. |
+| Author index | `index,follow` | Default social image | `CollectionPage`, `ItemList` | List authors or author pages represented visibly. |
+| Author detail | `index,follow` | Author image or default social image | `ProfilePage`, `Person` or `Organization`, article `ItemList` | Anonymous/collective authors need explicit type handling. |
+| Bibliography | `index,follow` | Default social image | `CollectionPage`, `ItemList`, conservative source entries | Use `CreativeWork` only until source typing improves. |
+| Search | `noindex,follow` by default | Default social image | Plain `WebPage` only | Static search landing page is useful to users, but not a search-result page. |
+| 404 | `noindex,follow` | Default social image optional | Plain `WebPage` only | Keep accessible navigation, no fake structured data. |
+| Legacy redirect | `noindex,follow` | None required | None required | Canonical + meta refresh + fallback link are the contract. |
+
+### Stable Entity ID Policy
+
+Use canonical URLs plus fragments so JSON-LD nodes can reference each other
+without duplicating identity:
+
+- Site: `{siteUrl}/#website`
+- Publisher: `{siteUrl}/#publisher`
+- Page: `{canonicalUrl}#webpage`
+- Article or announcement: `{canonicalUrl}#article`
+- Author entity: `{authorUrl}#author`
+- Collection/list page: `{canonicalUrl}#collection`
+- Item list: `{canonicalUrl}#itemlist`
+- Bibliography source, after source IDs are stable:
+  `{siteUrl}/bibliography/#source-{sourceId}`
+
+IDs must be deterministic, canonical, and generated from route helpers or
+canonical content IDs. Do not build them by hand in visual components.
+
+### Cross-Cutting Acceptance Criteria
+
+Every implementation milestone should preserve these invariants:
+
+- Every shareable HTML route has a title, description, canonical URL,
+  language, robots policy, Open Graph title/type/url/description, Twitter
+  metadata, and either a route social image or default social image.
+- Every emitted JSON-LD block parses as JSON, uses stable `@id` values, matches
+  visible page content, and avoids unsupported claims.
+- Robots policy, sitemap inclusion, feed inclusion, and public content-index
+  inclusion stay aligned. A route or entry that is intentionally `noindex` or
+  hidden from public discovery must not leak through another machine-readable
+  surface.
+- Article and announcement metadata is generated from content data and site
+  config, not duplicated in templates.
+- Author-facing metadata remains small and validated.
+- Generated output remains static-first with no new runtime JavaScript for
+  metadata.
+- Accessibility gates distinguish site-owned markup from third-party iframe
+  internals.
+- Release verification includes metadata tests, `html-validate`, axe,
+  Lighthouse where applicable, and existing release checks.
+
+### Recommended Implementation Order
+
+Implement in dependency order:
+
+1. Metadata contract and route matrix tests.
+2. Site identity config, default social image, and sitewide JSON-LD.
+3. Route-family structured data.
+4. Article/announcement enrichment and explicit modified-date field.
+5. Scholar/bibliography enrichment.
+6. Validation tooling and docs.
+7. Typed special schemas.
+8. AI-friendly content surfaces.
+
+Milestones should not skip the validation layer. If a milestone adds metadata
+without tests or built-output checks, the work is not complete.
+
+## Research Baseline
+
+### Search Metadata And Structured Data
+
+Google Search Central frames structured data as explicit page information that
+helps Google understand page content. Google recommends JSON-LD where possible
+and stresses that structured data should match visible page content and follow
+the relevant feature guidelines.
+
+High-value Google Search structured-data areas for this platform:
+
+- `Article`, `NewsArticle`, and `BlogPosting` for article-like entries.
+- `Organization` and `Person` for publisher and author identity.
+- `BreadcrumbList` for site hierarchy.
+- `ProfilePage` for author pages where the page is about a person or
+  organization.
+- `Review` only when a page is truly a review and the reviewed item/rating data
+  is visible and truthful.
+- `ItemList` and `CollectionPage` are Schema.org vocabulary rather than a
+  guaranteed Google rich-result feature, but they are valuable for machine
+  readability of archives, collections, tags, and categories.
+
+Google's rich result gallery is narrower than Schema.org. That distinction
+matters: not every schema type creates visible Search UI, but well-formed
+schema can still help downstream tools, AI agents, crawlers, and internal
+platform features understand the site.
+
+### Social Previews
+
+Open Graph requires `og:title`, `og:type`, `og:image`, and `og:url` for a
+complete graph object. The site already emits the core fields, including image
+dimensions/type/alt when an image exists. The main issue is that many index or
+directory pages have no social image fallback, so they do not emit `og:image`.
+
+For a platform, social-preview behavior should be:
+
+- Every public shareable page gets a complete canonical social object.
+- Article pages use a generated 1200x630 JPG based on article image/fallback.
+- Directory and utility pages use a configurable site default image.
+- All social images include width, height, type, and alt text when available.
+- Article pages also emit article-specific Open Graph fields.
+
+### Scholar And Academic Discoverability
+
+Google Scholar expects bibliographic metadata in the page head and discoverable
+full-text files. The site already emits:
+
+- `citation_title`
+- one or more `citation_author`
+- `citation_publication_date`
+- `citation_pdf_url` when the article PDF is enabled
+
+The next useful fields are:
+
+- `citation_language`
+- `citation_keywords`
+- `citation_abstract`
+- `citation_online_date` if it differs from publication date
+- `citation_reference` after bibliography metadata is stable enough to expose
+  citation strings reliably
+
+Do not invent journal metadata, volume/issue metadata, institution metadata, or
+modified dates unless the site actually owns that information.
+
+### Semantic HTML And Accessibility
+
+W3C WAI guidance reinforces the site's current direction:
+
+- Use real page structure: landmarks, headings, navigation, main content, and
+  semantic grouping.
+- Use heading levels to describe page outline and subsection hierarchy.
+- Give informative images meaningful alternatives.
+- Give decorative images empty alternatives so assistive technology can skip
+  them.
+
+Important audit note: the built output contains decorative brand/logo images
+with shorthand `alt` attributes. In HTML this represents an empty attribute
+value, so it is semantically equivalent to `alt=""`. Some simple scanners may
+flag it as missing because they search for `alt=` text. That is a scanner
+limitation, not necessarily an accessibility failure. We should validate with
+real HTML parsers, axe, html-validate, and browser accessibility snapshots
+before changing decorative alt handling.
+
+### AI-Agent And Machine Readability
+
+There is no separate magic metadata layer for AI agents. The highest-value
+machine-readability work is the same foundation that helps search, readers, and
+assistive technology:
+
+- Clean semantic HTML.
+- Stable canonical URLs.
+- Complete titles/descriptions/headings.
+- Structured data that truthfully describes page entities.
+- RSS, sitemap, and robots metadata.
+- Machine-readable author, publisher, date, tag, category, citation, PDF, and
+  bibliography relationships.
+- Predictable content schemas and stable route helpers.
+- Minimal client-side dependence for primary content.
+
+`llms.txt` is a possible later output after the canonical metadata and content
+index surfaces exist. It should not replace standard web semantics and
+structured data.
+
+## Current-State Inventory
+
+### Base Document Metadata
+
+`BaseLayout` and `SiteHead` currently provide the core document layer:
+
+- `<!doctype html>`
+- `<html lang={siteConfig.identity.language}>`
+- charset and viewport
+- SVG favicon and Apple touch icon
+- canonical URL
+- page title
+- meta description
+- RSS alternate link
+- Open Graph site name, type, title, description, URL
+- optional Open Graph image, dimensions, type, and alt
+- Twitter card, title, description, optional image and alt
+- skip link targeting `<main id="content">`
+
+This is a solid baseline.
+
+Immediate improvements:
+
+- Add `og:locale` from site config.
+- Add `twitter:site` and optional `twitter:creator` from site config.
+- Add default social image fallback for shareable non-article pages.
+- Add `theme-color`, `color-scheme`, and `application-name` if the design tokens
+  can provide stable values.
+- Add route-aware `robots` metadata where needed, especially search/404/utility
+  routes if the platform chooses `noindex`.
+
+### Structured Data
+
+The generated output currently contains 59 JSON-LD blocks, all `BlogPosting`,
+matching the 59 article pages. Representative article JSON-LD includes:
+
+- `@context`
+- `@type: BlogPosting`
+- `articleSection`
+- `author`
+- `datePublished`
+- `description`
+- `headline`
+- `image`
+- `keywords`
+- `mainEntityOfPage`
+- `publisher`
+- `url`
+
+Missing structured-data coverage:
+
+- sitewide `WebSite`
+- sitewide `Organization` or `Person` publisher entity
+- `BreadcrumbList` for major routes
+- `CollectionPage`/`ItemList` for home modules, article archives, category
+  pages, tag pages, collection pages, author indexes, and bibliography
+- `ProfilePage` for author pages
+- announcement article-like JSON-LD
+- richer article fields such as `inLanguage`, `isPartOf`, `dateModified` when
+  available, `mainEntityOfPage` as a `WebPage` object, and publisher logo/url
+- citation-aware structured data after bibliography data is stable
+
+### Article Pages
+
+Article pages are the strongest route type:
+
+- Semantic `<article>` layout.
+- H1 title.
+- Category, author, and date metadata.
+- Article actions for cite/share/PDF.
+- Tailwind Typography prose.
+- In-article table of contents.
+- Generated article images as figures with inspect behavior.
+- References, bibliography, tags, next article, support block, and related
+  category block.
+- Scholar meta and article JSON-LD.
+
+Planned improvements:
+
+- Add Open Graph article properties:
+  - `article:published_time`
+  - `article:modified_time` only when available
+  - `article:author`
+  - `article:section`
+  - repeated `article:tag`
+- Add `dateModified` only after we add an `updated` or `modified` field with a
+  truthful authoring policy.
+- Add `citation_language`, `citation_keywords`, and `citation_abstract`.
+- Add `citation_reference` and/or Schema.org `citation` from structured
+  bibliography data once citation strings are reliable.
+- Defer `ScholarlyArticle` unless we define a truthful, author-controlled
+  policy for explicitly scholarly pages. The default should remain
+  `BlogPosting` or `Article`.
+
+### Announcements
+
+Announcements are article-like but separate from public article aggregations.
+They use public page metadata but currently lack their own JSON-LD.
+
+Recommended behavior:
+
+- Emit `Article` or `BlogPosting` JSON-LD for announcement pages.
+- Do not emit Scholar metadata by default.
+- Keep announcement visibility controls separate from schema truthfulness.
+- Include announcements in feed where `visibility.feed` and feature config
+  allow it, which the site already does.
+
+### Author Pages
+
+Author pages have titles, descriptions, canonical URLs, and visible article
+lists. They do not currently expose author structured data.
+
+Recommended behavior:
+
+- Emit `ProfilePage` with `mainEntity` as `Person` or `Organization` based on
+  author type.
+- Include author URL, display name, website, socials as `sameAs`, aliases as
+  `alternateName`, and short bio as description when present.
+- Keep anonymous/collective author behavior explicit so we do not mislabel
+  anonymous entities as normal people.
+
+### Categories, Tags, Collections, And Archives
+
+These route families are important for human navigation and machine
+readability. They currently have basic titles, descriptions, canonical URLs, and
+visible lists, but no list structured data.
+
+Recommended behavior:
+
+- Emit `CollectionPage` for category, tag, collection, archive, and index pages.
+- Emit an `ItemList` of visible entries with `ListItem.position`, `url`, and
+  `name`.
+- Include page description and `mainEntity` where the page is fundamentally a
+  list.
+- Keep list size bounded when needed to avoid large JSON-LD output on huge
+  archives. A reasonable first rule is to emit items already visible on the
+  page, not every possible entry.
+
+### Bibliography
+
+The site bibliography is a valuable machine-readable entity. Today it is a
+human-readable route with links and backlinks, but no dedicated structured data.
+
+Recommended behavior:
+
+- Treat `/bibliography/` as a `CollectionPage`.
+- Emit an `ItemList` of source entries when the output size remains reasonable.
+- Use `CreativeWork`, `Book`, `ScholarlyArticle`, `Article`, `WebPage`, or
+  `VideoObject` for entries only after the citation model has reliable source
+  type fields. Until then, use conservative `CreativeWork` or list-only
+  metadata.
+- Link bibliography entries back to citing articles in visible HTML first; make
+  JSON-LD an enhancement.
+
+### Search And Utility Pages
+
+The search page has ordinary metadata and a canonical URL. Treat it as
+`noindex,follow` by default because the static page is a utility surface, not a
+search-result landing page with durable indexable content.
+
+Recommended behavior:
+
+- Emit `noindex,follow` for `/search/` unless a future product decision turns
+  it into a content-rich landing page.
+- Keep the title/description useful for users who arrive directly.
+- Do not add fake query-specific structured data to the static search route.
+
+### Redirect Pages
+
+The generated legacy redirect pages intentionally contain minimal HTML, a
+canonical link to the modern article URL, `meta refresh`, `robots noindex`, and
+a fallback anchor. The generated-output scan flags them as missing description,
+Open Graph, H1, main, and language.
+
+Those findings are acceptable for redirect-only documents. If we want to reduce
+scanner noise, we can add `<html lang>` and a tiny body structure to the
+redirect template, but this should be low priority because canonical/noindex
+behavior is the real contract.
+
+### Images And Alt Text
+
+Article prose images now generally have meaningful alt text and optimized Astro
+image output. Article preview image fallbacks were previously added.
+
+The audit found decorative support/social brand logos rendered as `<img alt>`
+with shorthand empty alt. That is correct only if the built HTML parser treats
+it as an empty value equivalent to `alt=""`; regex-based scanners may still
+misread it.
+
+Recommended behavior:
+
+- Keep meaningful alt text required for content images.
+- Keep decorative brand art empty-alt or hidden from assistive technology when
+  the surrounding link/button has an accessible name.
+- Consider rendering decorative SVG/logo assets in a way that serializes as
+  `alt=""` if third-party scanner false positives become operationally noisy.
+- Add a parser-based built-output check that differentiates missing alt,
+  empty decorative alt, and meaningful alt.
+
+### Generated Accessibility Sweep
+
+The repo already has Playwright + `@axe-core/playwright` coverage through
+`bun run test:a11y` and `bun run test:a11y:built`. The current CI-style scan is
+representative rather than exhaustive: it covers home, articles, one article,
+bibliography, categories, one category, about, and search, and fails only on
+serious or critical axe violations.
+
+For this research pass, a temporary full-site scanner ran axe across every
+non-redirect HTML route in the built preview:
+
+- 295 built HTML files found.
+- 61 legacy redirect documents skipped because their meta-refresh behavior
+  navigates before axe can reliably inspect the document.
+- 234 normal routes scanned.
+- 3 routes reported issues, with 5 total serious/critical violations.
+
+The reported violations were all inside third-party embed iframes rather than
+site-owned HTML:
+
+- `/articles/gondola-shrine/`: YouTube iframe internals use an `aria-label` on
+  a `div` without a valid role.
+- `/articles/the-memetic-bottleneck/`: YouTube iframe internals have the same
+  `aria-label` issue plus an unnamed internal video-info button.
+- `/articles/the-structure-of-hyperspatial-politics/`: SoundCloud iframe
+  internals use an invalid `role="bar"` and invalid `aria-role` attribute.
+
+Interpretation:
+
+- The broad sweep did not find serious or critical first-party template
+  failures.
+- Third-party widgets can still create accessibility debt for users, but we
+  cannot directly repair markup inside provider iframes.
+- Future automated axe coverage should separate first-party page checks from
+  third-party iframe audits. First-party gates should exclude provider iframes
+  or configure axe to avoid failing on markup we do not control. Third-party
+  iframe results should remain visible as a periodic risk report.
+- Embeds should keep accessible first-party wrappers, titles, captions, and
+  fallbacks. If a provider iframe remains noisy or poor for users, the platform
+  should prefer click-to-load embeds, plain links, transcripts, captions, or
+  provider-specific lightweight fallbacks rather than accepting the iframe as
+  the only content surface.
+
+## High-Value Immediate Work
+
+### 1. Add A Metadata Route Contract
+
+Create a typed route metadata model that every page family must satisfy before
+rendering `BaseLayout`.
+
+The model should normalize:
+
+- `title`
+- `description`
+- `canonicalPath`
+- route kind
+- Open Graph type
+- social image or default fallback
+- robots policy
+- sitemap/feed/content-index inclusion policy
+- page language/locale
+- optional structured-data graph nodes
+
+This should live in `src/lib/metadata` or equivalent, not inside visual
+components.
+
+Why it matters:
+
+- Prevents route drift.
+- Makes new pages harder to ship without metadata.
+- Gives tests one place to assert platform metadata contracts.
+- Makes future admin/UI configuration easier.
+
+### 2. Extend Site Identity Config
+
+`site/config/site.json` should grow from basic identity into platform identity.
+
+Recommended fields:
+
+```json
+{
+  "identity": {
+    "title": "The Philosopher's Meme",
+    "shortTitle": "TPM",
+    "description": "...",
+    "url": "https://thephilosophersmeme.com",
+    "language": "en",
+    "locale": "en_US",
+    "publisherName": "The Philosopher's Meme",
+    "publisherType": "Organization",
+    "logo": "...",
+    "defaultSocialImage": "...",
+    "sameAs": [
+      "https://x.com/philo_meme",
+      "https://www.facebook.com/thephilosophersmeme"
+    ],
+    "themeColor": "#...",
+    "timezone": "America/New_York"
+  }
+}
+```
+
+Keep optional fields optional. The platform should emit only truthful data.
+
+### 3. Add Sitewide JSON-LD
+
+Add one graph that identifies the site and publisher:
+
+- `WebSite`
+- `Organization` or `Person`
+- publisher logo
+- site URL
+- same-as profiles
+- language
+
+Use stable `@id` URLs so other JSON-LD nodes can refer to the site and
+publisher without duplicating data.
+
+### 4. Add List And Profile JSON-LD
+
+Add structured data for non-article route types:
+
+- `ProfilePage` for author pages.
+- `CollectionPage` + `ItemList` for archives, category pages, tag pages,
+  collection pages, announcements index, author index, and bibliography.
+- `BreadcrumbList` for major route hierarchies.
+
+Emit only items visible on the page or otherwise clearly represented by the
+page.
+
+### 5. Enrich Article And Announcement Metadata
+
+Enhance article JSON-LD and social metadata:
+
+- `inLanguage`
+- `isPartOf`
+- publisher `@id`
+- `mainEntityOfPage` as a `WebPage` object
+- `article:published_time`
+- `article:section`
+- `article:tag`
+- `twitter:site`
+- optional `twitter:creator`
+- `dateModified` and `article:modified_time` only after an author-facing
+  modified-date policy exists
+
+Extend announcement pages with article-like JSON-LD but skip Scholar metadata
+unless explicitly enabled later.
+
+### 6. Improve Scholar Metadata Carefully
+
+Immediate low-risk additions:
+
+- `citation_language`
+- `citation_keywords`
+- `citation_abstract`
+
+Future additions after bibliography stabilization:
+
+- `citation_reference`
+- source-level citation metadata in JSON-LD
+- richer PDF metadata validation
+
+### 7. Add Metadata Validation
+
+Add validation that covers source models and built output:
+
+- Unit tests for structured-data builders.
+- Component tests for `SiteHead` and route metadata normalization.
+- A built-output metadata matrix that checks representative pages by route
+  type.
+- JSON-LD parse validation and required-property assertions.
+- Social image checks for shareable route types.
+- Parser-based image-alt audit.
+- `html-validate`, accessibility, Lighthouse, and release checks as final gates.
+- Exhaustive axe audit mode that reports all first-party serious/critical
+  issues across built routes while treating third-party iframe internals as a
+  separately reported provider risk.
+
+## Forward-Looking Platform Opportunities
+
+### Optional Special Schemas
+
+Some articles may benefit from extra schema. This is now a planned platform
+capability, but it must be opt-in, typed, validated, and truthful.
+
+Potential frontmatter shape:
+
+```yaml
+schema:
+  kind: review
+  item:
+    type: VideoGame
+    name: Undertale
+    url: https://undertale.com/
+  rating:
+    value: 9
+    best: 10
+```
+
+Other future kinds:
+
+- `video` for pages centered on a video.
+- `audio` for podcast/music/audio pages.
+- `book` for book reviews or book announcements.
+- `event` for real events.
+- `dataset` for published data.
+- `software` for software/project writeups.
+- `faq` only for pages with visible question/answer content.
+
+Do not add generic freeform JSON-LD frontmatter as the primary interface. It is
+too easy for non-technical authors to create invalid or misleading data. Prefer
+typed, narrow frontmatter variants that the platform maps to valid JSON-LD.
+
+### Citation And Bibliography Graphs
+
+The article-reference system creates a meaningful foundation for richer
+metadata:
+
+- Article JSON-LD `citation` can point to structured source entries.
+- The site bibliography can become a machine-readable collection of cited
+  works.
+- PDF Scholar metadata can include `citation_reference`.
+- Backlinks from source entries to citing articles can become explicit
+  `isPartOf` or `subjectOf` relationships later.
+
+This work should be staged. Conservative citation strings and list metadata are
+safe to add first. Source-specific JSON-LD remains blocked on source typing: we
+should not emit a `ScholarlyArticle`, `Book`, or `VideoObject` for a
+bibliography entry until the citation model knows the entry type reliably.
+
+### AI-Friendly Content Surfaces
+
+Useful planned surfaces:
+
+- A concise machine-readable site manifest with routes and feature flags.
+- A public content index endpoint for articles, announcements, collections,
+  authors, categories, and tags.
+- Stable content IDs and `@id` values for authors, articles, collections,
+  source entries, and publisher identity.
+- Optional `llms.txt` only after we define what it should promise and how it
+  stays current.
+
+These should be generated from canonical content data, not hand-maintained.
+
+## Recommended Implementation Milestones
+
+### Milestone A: Metadata Contract Design
+
+Design and document the metadata contract before broad implementation. This is
+the highest-leverage milestone because every later milestone should compose
+through this model instead of adding route-specific head markup.
+
+Entry conditions:
+
+- None.
+
+Likely touch points:
+
+- New metadata helpers under `src/lib/metadata/` or equivalent.
+- Tests under `tests/src/lib/metadata*`.
+- Existing metadata tests in `tests/src/lib/seo.test.ts` and related route
+  tests.
+
+Deliverables:
+
+- Route metadata taxonomy.
+- Typed metadata view model.
+- Social image fallback policy.
+- Robots policy by route type.
+- Sitemap, feed, and public content-index inclusion policy by route/content
+  visibility.
+- JSON-LD graph ownership model.
+- Validation matrix.
+- Stable entity ID policy encoded as helpers.
+- Decision for `/search/`: default `noindex,follow` unless a later product
+  decision makes the static search page an indexable landing page.
+
+Primary risks:
+
+- Overfitting to current TPM content.
+- Making author frontmatter too complex.
+- Emitting metadata that does not match visible content.
+
+Tests to write early:
+
+- Metadata normalization tests for articles, announcements, list pages, author
+  pages, search, 404, and redirects.
+- Robots, sitemap, feed, and public content-index inclusion tests for public
+  pages, utility pages, noindex pages, and hidden content.
+- Stable `@id` helper tests.
+
+Acceptance criteria:
+
+- A developer can identify one metadata builder or normalization path for every
+  route family in the route matrix.
+- New route families cannot accidentally bypass the metadata contract without
+  becoming obvious in tests.
+- The contract distinguishes route metadata, site identity, content metadata,
+  and JSON-LD graph nodes.
+- No visual component owns content-specific metadata decisions.
+
+### Milestone B: Site Identity And Head Metadata
+
+Implement platform identity config and richer head tags.
+
+Dependencies:
+
+- Milestone A route metadata contract.
+
+Likely touch points:
+
+- `site/config/site.json`
+- site config schemas and tests under `src/lib/site-config*`
+- `src/components/seo/SiteHead.astro` or equivalent
+- social-image helpers and existing social-image tests
+- author/site-owner docs in `site/README.md` if configuration changes
+
+Deliverables:
+
+- Extended site identity schema and docs.
+- Default social image support for shareable routes.
+- `og:locale`, `twitter:site`, optional `twitter:creator`.
+- `theme-color`, `color-scheme`, and `application-name` if supported by tokens.
+- Sitewide `WebSite` and publisher JSON-LD.
+- Publisher identity fields: type, name, URL, logo, same-as links, language,
+  locale, and default social image.
+
+Tests:
+
+- Site config schema tests.
+- `SiteHead` component tests.
+- Built-output checks for article and non-article social tags.
+- Sitemap output checks for route classes with `index` and `noindex` policies.
+
+Acceptance criteria:
+
+- Every shareable HTML route has a complete Open Graph and Twitter preview
+  object, including a default image when route-specific image data is absent.
+- The publisher and website JSON-LD nodes use stable `@id`s and are referenced
+  by article/list/profile graph nodes later.
+- Missing optional identity fields do not produce empty or misleading meta tags.
+- Site owners can understand the new config fields from docs without reading
+  implementation code.
+
+### Milestone C: Route Structured Data
+
+Add route-family structured data.
+
+Dependencies:
+
+- Milestone A metadata contract.
+- Milestone B site identity graph IDs.
+
+Likely touch points:
+
+- JSON-LD builder helpers in `src/lib/metadata/`.
+- Route files under `src/pages/`.
+- Article/list/author/category/tag/collection data helpers under `src/lib/`.
+- Built-output verification scripts.
+
+Deliverables:
+
+- `BreadcrumbList` helpers.
+- `CollectionPage` and `ItemList` helpers.
+- `ProfilePage` helpers.
+- Route integration for authors, categories, tags, collections, archives,
+  bibliography, announcements, and home.
+- Bounded `ItemList` policy: emit items visibly represented on the page, not
+  invisible unbounded datasets.
+- Conservative bibliography metadata: list/page structure first, source-type
+  metadata later.
+
+Tests:
+
+- JSON-LD builder tests.
+- Route output tests for representative pages.
+- Build verifier checks for parseable JSON-LD.
+
+Acceptance criteria:
+
+- Home, articles/archive, authors, author detail, categories, tags,
+  collections, announcements index, bibliography, and article-like pages emit
+  appropriate structured data.
+- JSON-LD items match visible page content and canonical URLs.
+- Breadcrumbs are emitted only where they represent real hierarchy.
+- The implementation avoids duplicate or contradictory publisher/site nodes.
+
+### Milestone D: Article And Announcement Enrichment
+
+Enrich publishable metadata without changing author burden.
+
+Dependencies:
+
+- Milestone A metadata contract.
+- Milestone B site identity.
+- Milestone C structured-data helpers.
+
+Likely touch points:
+
+- Article and announcement content schemas.
+- Article route and announcement route metadata builders.
+- `SiteHead` article Open Graph rendering.
+- Scholar metadata helpers and tests.
+- Author-facing docs for the modified-date field.
+
+Deliverables:
+
+- More complete article JSON-LD.
+- Announcement JSON-LD.
+- Article Open Graph properties.
+- Explicit author-facing modified-date policy and schema field.
+- `dateModified` and `article:modified_time` emitted only when a truthful
+  modified date is present.
+- `inLanguage`, `isPartOf`, publisher `@id`, `WebPage` `mainEntityOfPage`,
+  `article:published_time`, `article:section`, and repeated `article:tag`.
+
+Tests:
+
+- Article/announcement component tests.
+- Existing PDF and social-image tests.
+- Built-output checks against representative article and announcement pages.
+
+Acceptance criteria:
+
+- Articles and announcements share the same publishable-entry metadata path
+  where appropriate, while preserving announcement-specific differences.
+- Announcements emit article-like schema but not Scholar metadata by default.
+- Modified dates are absent when authors do not set an explicit field.
+- Existing article authoring remains valid unless it contains invalid dates or
+  explicitly invalid new metadata.
+
+### Milestone E: Scholar And Bibliography Metadata
+
+Improve academic metadata and citation relationships.
+
+Dependencies:
+
+- Milestone D article metadata.
+- Existing article-reference/bibliography system.
+
+Likely touch points:
+
+- Article reference helpers under `src/lib/article-references/`.
+- Bibliography route/components.
+- Scholar metadata tests.
+- PDF generation metadata if Scholar/PDF output shares citation strings.
+
+Deliverables:
+
+- `citation_language`, `citation_keywords`, and `citation_abstract`.
+- Conservative `citation_reference` output when citation strings can be derived
+  reliably.
+- Conservative bibliography `CollectionPage`/`ItemList` output.
+- A staged design for source-typed bibliography JSON-LD once source typing is
+  available.
+- Documentation for what Scholar metadata does and does not promise.
+- Clear fallback behavior when an article has no references or when references
+  cannot be converted into high-quality citation strings.
+
+Tests:
+
+- Scholar meta tests.
+- Citation-reference validation once implemented.
+- Bibliography route JSON-LD parse tests.
+
+Acceptance criteria:
+
+- Scholar fields are emitted only when the platform has truthful source data.
+- `citation_reference` output is deterministic and does not expose malformed or
+  placeholder citation strings.
+- Bibliography structured data is conservative and useful without pretending to
+  know source types the model does not yet represent.
+
+### Milestone F: Metadata Validation Tooling
+
+Make drift visible.
+
+Dependencies:
+
+- Can begin after Milestone A; should expand as B-E land.
+
+Likely touch points:
+
+- Existing verifier scripts under `scripts/`.
+- SEO/route tests under `tests/src/lib/` and `tests/config/`.
+- Playwright accessibility tests under `tests/a11y/`.
+- `PACKAGE_SCRIPTS.md` if new scripts are added.
+- CI workflow if a new release gate is promoted.
+
+Deliverables:
+
+- Route metadata matrix test.
+- Sitemap/feed/content-index policy test.
+- Built-output JSON-LD parse test.
+- Parser-based image-alt audit.
+- First-party full-site axe sweep with redirect handling and third-party iframe
+  reporting separated from site-owned failures.
+- Social-preview metadata test for route classes.
+- Docs describing which validators to run manually before major releases.
+- Clear distinction between blocking release gates and advisory/manual
+  validators.
+
+Manual validation tools:
+
+- Google Rich Results Test for representative pages.
+- Schema.org validator for non-Google schema types.
+- Lighthouse SEO and accessibility audits.
+- Browser accessibility snapshots for core templates.
+- Social preview validators where available.
+
+Acceptance criteria:
+
+- A developer can run one documented validation path and know whether metadata
+  is release-ready.
+- Built-output tests fail on missing canonical metadata, invalid JSON-LD,
+  missing required social images, broken robots policy, and real missing image
+  alt text.
+- Sitemap/feed/content-index tests fail when noindex or hidden content leaks
+  into public machine-readable discovery surfaces.
+- Third-party iframe accessibility issues are reported but do not fail
+  first-party markup gates.
+- Existing release checks remain green or are intentionally updated with docs.
+
+### Milestone G: Typed Special Schemas
+
+Add optional author-facing schema variants after the core route metadata model
+is stable.
+
+Dependencies:
+
+- Milestone A metadata contract.
+- Milestone D article/announcement enrichment.
+- Milestone F validation infrastructure.
+
+Likely touch points:
+
+- Content schema definitions.
+- JSON-LD builders.
+- Author docs in `site/README.md`.
+- Tests for invalid content fixtures if available.
+
+Deliverables:
+
+- Narrow frontmatter schemas for approved kinds such as review, video, audio,
+  book, event, dataset, software, and FAQ.
+- Source-to-JSON-LD builders that emit only fields supported by visible page
+  content and validated frontmatter.
+- Author docs explaining when to use each schema kind and when not to use it.
+- No generic arbitrary JSON-LD escape hatch in the first implementation.
+
+Tests:
+
+- Schema validation tests for valid and invalid frontmatter.
+- JSON-LD builder tests for each supported kind.
+- Representative article output tests proving structured data matches visible
+  page content.
+
+Acceptance criteria:
+
+- Authors can opt into common schema types without learning JSON-LD.
+- Invalid combinations fail at content validation time.
+- Optional schemas never emit fields that are absent from visible content or
+  validated frontmatter.
+- The first implementation may support a smaller subset of schema kinds if each
+  supported kind is complete and well tested.
+
+### Milestone H: AI-Friendly Content Surfaces
+
+Generate machine-readable indexes from canonical content data.
+
+Dependencies:
+
+- Milestone A metadata contract.
+- Milestone B stable site identity.
+- Milestone C route structured data.
+
+Likely touch points:
+
+- Static endpoint routes under `src/pages/`.
+- Content/route helpers under `src/lib/`.
+- Build verifier scripts.
+- Documentation for platform consumers and site owners.
+
+Deliverables:
+
+- Stable entity `@id` policy for site, publisher, authors, articles,
+  announcements, collections, categories, tags, and bibliography sources.
+- Public content index endpoint for route discovery and article metadata.
+- Route/entity manifest for platform tooling and future admin UI work.
+- Decision document for whether to add `llms.txt`, including what it promises
+  and how it remains current.
+
+Tests:
+
+- Endpoint schema tests.
+- Built-output checks for stable IDs and canonical URLs.
+- Snapshot or contract tests that make accidental field removals visible.
+
+Acceptance criteria:
+
+- Public indexes are generated from canonical content data and route helpers,
+  not hand-maintained JSON.
+- Endpoints avoid private drafts, hidden content, or internal implementation
+  details, and they respect the same robots/visibility policy used by sitemap
+  and feed generation.
+- The payload is useful for agents/tools without bloating normal page HTML.
+- `llms.txt` is not added until the project defines a truthful maintenance
+  contract for it.
+
+## Action Priority
+
+1. Metadata contract and default social image fallback.
+2. Site identity config and sitewide JSON-LD.
+3. Route structured data for author/list pages.
+4. Article and announcement enrichment, including explicit modified dates.
+5. Scholar/bibliography expansion.
+6. Validation tooling and docs.
+7. Typed special-schema frontmatter after the core metadata contract is stable.
+8. AI-friendly content surfaces generated from canonical data.
+9. Embed accessibility strategy as a separate deferred embed UX project.
+
+This order improves visible sharing, SEO, and machine readability quickly while
+building the abstractions needed for long-term platform configurability.
+
+## Developer Handoff
+
+### Readiness
+
+This audit is ready to hand off for implementation. Milestones A-F are
+unblocked and should be treated as the first implementation batch. Milestones G
+and H are planned platform work, but they should wait until the core metadata
+contract, site identity graph, route structured data, and validation tooling are
+stable enough to support them cleanly.
+
+### First Implementation Batch
+
+Implement these in order:
+
+1. `src/lib/metadata` contract, stable ID helpers, route metadata matrix tests.
+2. Extended site identity config and default social image fallback.
+3. Sitewide `WebSite` and publisher JSON-LD.
+4. `CollectionPage`, `ItemList`, `ProfilePage`, and breadcrumb helpers.
+5. Article/announcement enrichment and explicit `updated` field policy.
+6. Scholar/bibliography metadata expansion.
+7. Built-output validation scripts and docs.
+
+Each item should ship with tests in the same milestone. Do not batch all code
+first and add validation at the end.
+
+### Required Test Plan
+
+At minimum, implementation should add or update tests for:
+
+- Metadata normalization for every route family in the route matrix.
+- Site identity schema validation.
+- `SiteHead` output for route-specific and default social images.
+- JSON-LD builder output and stable `@id` relationships.
+- Built HTML parsing for representative route types.
+- Parser-based image-alt audit.
+- First-party full-site axe scan behavior with third-party iframe handling.
+- Scholar metadata and citation-reference behavior.
+- Author docs for new frontmatter/config fields.
+
+### Blocking Risks To Watch
+
+- Emitting metadata that does not match visible content.
+- Creating author-facing frontmatter that is too broad or too technical.
+- Duplicating metadata logic between routes, layouts, and components.
+- Letting route files hand-build canonical URLs or entity IDs.
+- Treating third-party iframe accessibility errors as first-party template
+  failures.
+- Adding AI/content-index endpoints that expose hidden content, drafts, or
+  internal implementation details.
+
+### Non-Blocking Follow-Ups
+
+- Source-type-specific bibliography JSON-LD waits on reliable source typing.
+- `ScholarlyArticle` waits on an explicit editorial policy.
+- `llms.txt` waits on a clear generated-content contract.
+- Click-to-load embeds, transcripts, and lightweight embed fallbacks belong to
+  a separate embed UX milestone.
+
+## References
+
+- Google Search Central: Structured data introduction:
+  <https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data>
+- Google Search Central: Article structured data:
+  <https://developers.google.com/search/docs/appearance/structured-data/article>
+- Google Search Central: Organization structured data:
+  <https://developers.google.com/search/docs/appearance/structured-data/organization>
+- Google Search Central: Breadcrumb structured data:
+  <https://developers.google.com/search/docs/appearance/structured-data/breadcrumb>
+- Google Search Central: Profile page structured data:
+  <https://developers.google.com/search/docs/appearance/structured-data/profile-page>
+- Google Search Central: Review snippet structured data:
+  <https://developers.google.com/search/docs/appearance/structured-data/review-snippet>
+- Google Search Central: Special tags and robots controls:
+  <https://developers.google.com/search/docs/crawling-indexing/special-tags>
+- Google Scholar inclusion guidelines:
+  <https://scholar.google.com/intl/en/scholar/inclusion.html>
+- W3C WAI image alt decision tree:
+  <https://www.w3.org/WAI/tutorials/images/decision-tree/>
+- W3C WAI page structure tutorial:
+  <https://www.w3.org/WAI/tutorials/page-structure/>
+- Open Graph protocol:
+  <https://ogp.me/>
+- Schema.org Article:
+  <https://schema.org/Article>
+- Schema.org BlogPosting:
+  <https://schema.org/BlogPosting>
+- Schema.org WebSite:
+  <https://schema.org/WebSite>
+- Schema.org Organization:
+  <https://schema.org/Organization>
+- Schema.org BreadcrumbList:
+  <https://schema.org/BreadcrumbList>
+- Schema.org ProfilePage:
+  <https://schema.org/ProfilePage>
+- Schema.org CollectionPage:
+  <https://schema.org/CollectionPage>
+- Schema.org ItemList:
+  <https://schema.org/ItemList>

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -4,6 +4,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 
 import { articleImagePolicyCacheKey } from "./src/lib/article-image-policy";
+import { sitemapIncludesPath } from "./src/lib/metadata";
 import { siteConfig } from "./src/lib/site-config";
 import { projectRelativePath, siteInstance } from "./src/lib/site-instance";
 import { siteRedirects } from "./src/lib/site-redirects";
@@ -13,6 +14,12 @@ import {
 } from "./src/rehype-plugins/articleImages";
 import { remarkArticleReferences } from "./src/remark-plugins/articleReferences";
 
+function sitemapPagePathname(page: string): string {
+  return (
+    page.replace(/^[a-z][a-z\d+\-.]*:\/\/[^/]+/iu, "").split(/[?#]/u)[0] ?? "/"
+  );
+}
+
 export default defineConfig({
   compressHTML: true,
   image: {
@@ -21,7 +28,12 @@ export default defineConfig({
     layout: "constrained",
     responsiveStyles: false,
   },
-  integrations: [mdx(), sitemap()],
+  integrations: [
+    mdx(),
+    sitemap({
+      filter: (page) => sitemapIncludesPath(sitemapPagePathname(page)),
+    }),
+  ],
   markdown: {
     rehypePlugins: [
       [rehypeArticleImages, { policyCacheKey: articleImagePolicyCacheKey }],

--- a/docs/CLOUDFLARE_WORKERS_MIGRATION.md
+++ b/docs/CLOUDFLARE_WORKERS_MIGRATION.md
@@ -128,15 +128,17 @@ Current state:
 
 Cloudflare target:
 
-- Keep content `legacyPermalink` metadata as the source of truth.
+- Keep content `legacyPermalink` metadata as the source of truth for
+  article/announcement permalink redirects.
+- Keep hand-written compatibility redirects in `site/config/redirects.json`.
 - Generate a Cloudflare-compatible `_redirects` file into the deployed static
-  assets.
+  assets from both sources.
 - Do not ask authors to edit `_redirects` manually.
 
 Recommended generated format:
 
 ```text
-# Generated from article legacyPermalink metadata. Do not edit by hand.
+# Generated from site redirects and article legacyPermalink metadata. Do not edit by hand.
 /2021/11/30/what-is-a-meme/ /articles/what-is-a-meme/ 301
 ```
 
@@ -145,7 +147,8 @@ Why generate instead of hand-authoring:
 - Avoids drift between article metadata, Astro config, local verification, and
   Cloudflare deploys.
 - Keeps the site-instance authoring surface JSON-based and GUI-friendly.
-- Lets tests assert a single redirect source of truth.
+- Lets tests assert redirect parity while still allowing explicit
+  hand-written compatibility redirects.
 
 Implementation options:
 
@@ -296,8 +299,11 @@ Focused tests:
   - appends status code `301`;
   - rejects malformed metadata and duplicate sources;
   - writes into the configured output directory.
-- Legacy redirect parity test:
-  - Cloudflare redirects match content-derived legacy permalink redirects.
+- Legacy redirect parity tests:
+  - Cloudflare redirects include content-derived legacy permalink redirects;
+  - Cloudflare redirects include site-owned compatibility redirects;
+  - duplicate matching redirects collapse to one output line;
+  - conflicting redirect destinations fail generation.
 - CI workflow test:
   - deploy job uses `cloudflare/wrangler-action@v3`;
   - deploy job consumes `verified-dist`;
@@ -333,7 +339,8 @@ Cloudflare is now the production host. The cleanup state is:
 
 2. **Redirect generation**
    Add `build:cloudflare` to generate `dist/_redirects` from content
-   `legacyPermalink` metadata, then verify it in tests and build checks.
+   `legacyPermalink` metadata and `site/config/redirects.json`, then verify it
+   in tests and build checks.
 
 3. **CI preview deploy**
    Add a Cloudflare deploy job that consumes `verified-dist` and deploys only
@@ -354,8 +361,9 @@ Cloudflare is now the production host. The cleanup state is:
   behavior.
 
 - **Redirect drift.**
-  Generate `_redirects` from content `legacyPermalink` metadata and test the
-  output.
+  Generate `_redirects` from content `legacyPermalink` metadata plus
+  site-owned redirects, deduplicate matching entries, fail conflicting entries,
+  and test the output.
 
 - **Different 404 behavior from GitHub Pages.**
   Use `not_found_handling = "404-page"` and smoke test the status code.

--- a/docs/CLOUDFLARE_WORKERS_MIGRATION.md
+++ b/docs/CLOUDFLARE_WORKERS_MIGRATION.md
@@ -197,24 +197,39 @@ Open question:
 
 ## Headers
 
-Cloudflare Static Assets supports `_headers` in the asset directory. We do not
-need `_headers` to migrate, but it is worth considering after the deploy is
-stable.
+Cloudflare Static Assets supports `_headers` in the asset directory. The active
+site uses `_headers` for extensionless compatibility endpoints that need a
+specific MIME type and for long-lived caching of Astro fingerprinted assets.
 
-Potential future headers:
+Current headers:
 
 ```text
 /_astro/*
-  Cache-Control: public, max-age=31536000, immutable
+  Cache-Control: public, max-age=31556952, immutable
+
+/.well-known/traffic-advice
+  Content-Type: application/trafficadvice+json; charset=utf-8
+  X-Content-Type-Options: nosniff
 ```
 
-Reasons to defer:
+`/_astro/*` is intentionally the only immutable cache rule. Astro emits source
+assets such as optimized images, CSS, and JavaScript into `_astro` with
+fingerprinted filenames, so a changed asset receives a changed URL. HTML, RSS,
+sitemaps, PDFs, Pagefind files, root icons, and other non-fingerprinted static
+files should keep Cloudflare's default revalidation behavior or receive a
+separate, shorter policy after measurement.
 
-- Cloudflare already applies default `Cache-Control`, `ETag`, and content-type
-  headers to static assets.
-- We should measure the deployed behavior before adding cache policy.
-- The current Astro fingerprinted asset names make immutable caching plausible,
-  but HTML and feeds must remain revalidated.
+`/.well-known/traffic-advice` is served from
+`site/public/.well-known/traffic-advice` and currently allows private prefetch
+proxy traffic:
+
+```json
+[{ "user_agent": "prefetch-proxy", "fraction": 1 }]
+```
+
+This is intentional for TPM because the site is static, public, and safe to
+prefetch. If future analytics, traffic-cost, or abuse concerns appear, reduce
+the fraction or switch the endpoint to `disallow`.
 
 ## CI Changes
 

--- a/docs/PLATFORM_MODULES.md
+++ b/docs/PLATFORM_MODULES.md
@@ -16,9 +16,10 @@ incidental TPM implementation details.
   `feed`, `home`, `publishable`, and `tags`.
 - Routes and features
   Owns URL construction, static path helpers, optional feature routes,
-  navigation, SEO, social previews, share targets, support CTAs, site config,
-  site instance paths, and redirects. Current modules: `feature-routes`,
-  `navigation`, `routes`, `seo`, `share-targets`, `site-config`,
+  navigation, metadata contracts, SEO, social previews, share targets, support
+  CTAs, site config, site instance paths, and redirects. Current modules:
+  `feature-routes`, `metadata`, `navigation`, `routes`, `seo`,
+  `share-targets`, `site-config`,
   `site-config-defaults`, `site-instance`, `site-redirects`, `social-images`,
   `static-paths`, and `support`.
 - Article rendering

--- a/docs/PLATFORM_MODULES.md
+++ b/docs/PLATFORM_MODULES.md
@@ -18,8 +18,8 @@ incidental TPM implementation details.
   Owns URL construction, static path helpers, optional feature routes,
   navigation, metadata contracts, SEO, social previews, share targets, support
   CTAs, site config, site instance paths, and redirects. Current modules:
-  `feature-routes`, `metadata`, `navigation`, `routes`, `seo`,
-  `share-targets`, `site-config`,
+  `feature-routes`, `metadata`, `navigation`, `routes`, `semantic-metadata`,
+  `seo`, `share-targets`, `site-config`,
   `site-config-defaults`, `site-instance`, `site-redirects`, `social-images`,
   `static-paths`, and `support`.
 - Article rendering

--- a/docs/components/articles/ArticleHeader.md
+++ b/docs/components/articles/ArticleHeader.md
@@ -9,6 +9,10 @@ title, description, date/author metadata, and quiet article utilities such as
 the visible `Cite`, `Share`, and `PDF` actions. Their accessible names remain
 `Cite this article`, `Share this article`, and `Save PDF`.
 
+When article-like frontmatter includes validated `semantic` metadata, the header
+also renders a compact visible details surface so structured metadata is
+represented in reader-visible page content.
+
 ## Public Contract
 
 - `author?: string | undefined`
@@ -20,6 +24,7 @@ the visible `Cite`, `Share`, and `PDF` actions. Their accessible names remain
 - `title: string`
 - `citation?: ArticleCitationMenuViewModel | undefined`
 - `pdf?: ArticlePdfViewModel | undefined`
+- `semanticDetails?: SemanticDetailsViewModel | undefined`
 - `share?: ArticleShareMenuViewModel | undefined`
 
 Public props should remain narrow and semantic. Do not add broad configuration
@@ -36,6 +41,7 @@ ArticleLayout
       AuthorByline
     ArticleCitationMenu
     ArticleShareMenu
+    SemanticDetails
     PDF TextLink
 ```
 
@@ -57,6 +63,10 @@ title, description, or byline into overlap. The action cluster is aligned to the
 inline end of the article width, while popovers and generated PDF output must
 not reserve article space. The header should remain readable when any utility is
 absent.
+
+Semantic details should stay compact and subordinate. They may add a small
+visible details block under the description, but must not become a card inside
+the article header or push action popovers into the document flow.
 
 ## Layering And Scrolling
 
@@ -99,6 +109,8 @@ visible, and CTAs distinguishable from neutral actions.
 - keeps the visible `PDF` action subordinate in the category/action row,
   accessible as `Save PDF`, pointed at the generated same-directory PDF, and
   excluded from print/PDF output when PDF metadata is available.
+- renders semantic details only when normalized semantic metadata has visible
+  facts, and keeps those facts in a real description list.
 - opens the citation popover without increasing article header height or
   changing the title, metadata, or description positions.
 - does not create an awkward header-to-body gap when no hero image is rendered.

--- a/docs/components/articles/SemanticDetails.md
+++ b/docs/components/articles/SemanticDetails.md
@@ -1,0 +1,31 @@
+# SemanticDetails
+
+`SemanticDetails` renders the visible facts for optional article-like
+`semantic` metadata. It keeps structured-data parity explicit: if a semantic
+profile emits JSON-LD, the same normalized facts should be visible to readers.
+
+## Ownership
+
+- Owns a compact details surface for validated semantic metadata.
+- Renders only non-empty facts supplied by `semanticDetailsViewModel()`.
+- Does not decide which semantic profile is valid.
+- Does not build JSON-LD.
+
+## Accessibility
+
+Use an `aside` with an accessible label matching the profile heading. Facts are
+rendered as a real description list so labels and values remain associated.
+Links remain ordinary links.
+
+## Styling
+
+Use quiet article-header styling: semantic foreground/muted/border tokens, no
+card nesting, and compact vertical rhythm. The component should not dominate
+the article header; it is supporting metadata.
+
+## Tests
+
+- Component rendering and empty-state behavior:
+  `tests/src/components/articles/SemanticDetails.vitest.ts`.
+- Normalized details and JSON-LD source data:
+  `tests/src/lib/semantic-metadata.test.ts`.

--- a/docs/components/seo/ArticleJsonLd.md
+++ b/docs/components/seo/ArticleJsonLd.md
@@ -9,6 +9,10 @@ Source: `src/components/seo/ArticleJsonLd.astro`
 It should reflect the same canonical URL, title, dates, category, images, and
 authors that visible article surfaces use.
 
+If an article opts into validated `semantic` frontmatter, the component emits a
+JSON-LD graph containing the base `BlogPosting` plus the semantic profile node.
+The base article links to semantic nodes through `about`.
+
 ## Public Contract
 
 - `article: ArticleEntry`
@@ -27,6 +31,7 @@ ArticleLayout / SEO head boundary
   ArticleJsonLd
     route helpers
     SEO helpers
+    semantic metadata helpers
 ```
 
 This component should consume normalized article and author summaries from the
@@ -75,8 +80,12 @@ visible, and CTAs distinguishable from neutral actions.
 - emits structured `Person` or `Organization` author objects only when author
   metadata supports that interpretation.
 - falls back conservatively while legacy `author` strings still exist.
+- emits optional semantic profile nodes only from validated frontmatter, never
+  from prose inference or arbitrary JSON-LD.
 
 ## Follow-Up Notes
 
 - Do not infer personal websites, social profiles, avatars, or real identities
   in JSON-LD. Public author metadata requires explicit content-owner approval.
+- Keep semantic JSON-LD paired with visible `SemanticDetails` output so hidden
+  machine-only facts do not drift away from the reader-facing page.

--- a/eslint/config/overrides.ts
+++ b/eslint/config/overrides.ts
@@ -38,7 +38,11 @@ export function createOverrideConfigs(): readonly ConfigWithExtends[] {
       },
     },
     {
-      files: ["src/components/seo/ArticleJsonLd.astro"],
+      files: [
+        "src/components/seo/AnnouncementJsonLd.astro",
+        "src/components/seo/ArticleJsonLd.astro",
+        "src/components/seo/SiteHead.astro",
+      ],
       rules: {
         "astro/no-set-html-directive": "off",
       },

--- a/examples/docs-site/config/site.schema.json
+++ b/examples/docs-site/config/site.schema.json
@@ -417,13 +417,39 @@
           "type": "string",
           "minLength": 2
         },
+        "locale": {
+          "default": "en_US",
+          "type": "string",
+          "minLength": 2
+        },
+        "logo": {
+          "type": "string",
+          "minLength": 1
+        },
         "publisherName": {
           "type": "string",
           "minLength": 1
         },
+        "publisherType": {
+          "default": "organization",
+          "type": "string",
+          "enum": ["organization", "person"]
+        },
+        "sameAs": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
         "shortTitle": {
           "type": "string",
           "minLength": 1
+        },
+        "themeColor": {
+          "type": "string",
+          "pattern": "^#[\\da-f]{6}$"
         },
         "timezone": {
           "type": "string",

--- a/scripts/build/generate-cloudflare-redirects.ts
+++ b/scripts/build/generate-cloudflare-redirects.ts
@@ -4,12 +4,13 @@ import path from "node:path";
 import matter from "gray-matter";
 
 import { siteInstance } from "../../src/lib/site-instance";
+import { siteRedirects as currentSiteRedirects } from "../../src/lib/site-redirects";
 
 const CLOUDFLARE_STATIC_REDIRECT_LIMIT = 2_000;
 const CLOUDFLARE_REDIRECT_LINE_LIMIT = 1_000;
 const LEGACY_CONTENT_PATTERN = /\.mdx?$/iu;
 const GENERATED_HEADER =
-  "# Generated from article legacyPermalink metadata. Do not edit by hand.";
+  "# Generated from site redirects and article legacyPermalink metadata. Do not edit by hand.";
 const REDIRECT_STATUS = 301;
 
 /** Content directory and current public route prefix for legacy redirects. */
@@ -24,9 +25,12 @@ export interface CloudflareRedirectRule {
   readonly source: string;
 }
 
+type SiteRedirectMap = Readonly<Record<string, string>>;
+
 interface GenerateCloudflareRedirectsOptions {
   readonly outputDir?: string | undefined;
   readonly quiet?: boolean | undefined;
+  readonly siteRedirects?: SiteRedirectMap | undefined;
   readonly sources?: readonly LegacyRedirectSource[] | undefined;
 }
 
@@ -53,8 +57,8 @@ export function defaultLegacyRedirectSources(): LegacyRedirectSource[] {
 }
 
 /**
- * Generates Cloudflare's static `_redirects` file from legacy permalink
- * frontmatter.
+ * Generates Cloudflare's static `_redirects` file from site-owned redirects
+ * and legacy permalink frontmatter.
  *
  * @param options Optional output and content source overrides.
  * @returns The generated redirect file path and redirect count.
@@ -64,8 +68,9 @@ export async function generateCloudflareRedirects(
 ): Promise<{ count: number; path: string }> {
   const outputDir = options.outputDir ?? siteInstance.output.dist;
   const outputPath = path.join(outputDir, "_redirects");
-  const rules = await collectLegacyRedirectRules(
+  const rules = await collectCloudflareRedirectRules(
     options.sources ?? defaultLegacyRedirectSources(),
+    options.siteRedirects ?? currentSiteRedirects,
   );
   const output = formatCloudflareRedirects(rules);
 
@@ -79,6 +84,24 @@ export async function generateCloudflareRedirects(
   }
 
   return { count: rules.length, path: outputPath };
+}
+
+/**
+ * Reads generated content redirects and merges them with site-owned redirect
+ * config.
+ *
+ * @param sources Content directories and their current public route prefixes.
+ * @param configuredRedirects Hand-written site redirects.
+ * @returns Sorted Cloudflare redirect rules.
+ */
+export async function collectCloudflareRedirectRules(
+  sources: readonly LegacyRedirectSource[],
+  configuredRedirects: SiteRedirectMap = currentSiteRedirects,
+): Promise<CloudflareRedirectRule[]> {
+  return mergeCloudflareRedirectRules(
+    await collectLegacyRedirectRules(sources),
+    redirectRulesFromSiteRedirects(configuredRedirects),
+  );
 }
 
 /**
@@ -137,7 +160,7 @@ export async function collectLegacyRedirectRules(
 /**
  * Formats redirect rules for Cloudflare Workers Static Assets.
  *
- * @param rules Redirect rules derived from legacy permalink metadata.
+ * @param rules Redirect rules derived from site config and legacy permalink metadata.
  * @returns `_redirects` file content.
  */
 export function formatCloudflareRedirects(
@@ -187,6 +210,43 @@ function assertCloudflareRedirectLimits(
       `Cloudflare redirect line exceeds ${CLOUDFLARE_REDIRECT_LINE_LIMIT} characters for ${oversizedRule.source}.`,
     );
   }
+}
+
+function mergeCloudflareRedirectRules(
+  ...ruleSets: ReadonlyArray<readonly CloudflareRedirectRule[]>
+): CloudflareRedirectRule[] {
+  const redirects = new Map<string, CloudflareRedirectRule>();
+
+  for (const rules of ruleSets) {
+    for (const rule of rules) {
+      const previous = redirects.get(rule.source);
+
+      if (previous !== undefined && previous.destination !== rule.destination) {
+        throw new Error(
+          `Conflicting redirect destinations for ${rule.source}: ${previous.destination} and ${rule.destination}.`,
+        );
+      }
+
+      redirects.set(rule.source, rule);
+    }
+  }
+
+  const mergedRules = Array.from(redirects.values()).sort((left, right) =>
+    left.source.localeCompare(right.source),
+  );
+
+  assertCloudflareRedirectLimits(mergedRules);
+
+  return mergedRules;
+}
+
+function redirectRulesFromSiteRedirects(
+  redirects: SiteRedirectMap,
+): CloudflareRedirectRule[] {
+  return Object.entries(redirects).map(([source, destination]) => ({
+    destination: destination.trim(),
+    source: normalizeLegacyPermalink(source),
+  }));
 }
 
 function currentContentUrl(routePrefix: string, file: string): string {

--- a/scripts/build/verify-build.ts
+++ b/scripts/build/verify-build.ts
@@ -1761,10 +1761,6 @@ function isAstroRedirectFallbackPage(
   html: string,
   relativeHtmlPath: string,
 ): boolean {
-  if (!isDatedHtmlPage(relativeHtmlPath)) {
-    return false;
-  }
-
   return (
     /<title>Redirecting to: [^<]+<\/title>/i.test(html) &&
     /<meta\s+http-equiv=["']refresh["']\s+content=["']0;url=[^"']+["']>/i.test(

--- a/scripts/build/verify-build.ts
+++ b/scripts/build/verify-build.ts
@@ -11,6 +11,7 @@ import {
   scholarPublicationDate,
 } from "../../src/lib/article-pdf";
 import { optionalFeatureRouteEntries } from "../../src/lib/feature-routes";
+import { sitemapIncludesPath } from "../../src/lib/metadata";
 import { type SiteConfig, siteConfig } from "../../src/lib/site-config";
 import { resolveSiteInstancePaths } from "../../src/lib/site-instance";
 import {
@@ -62,7 +63,9 @@ export interface BuildVerificationIssues {
   brokenLinks: string[];
   catalogLeaks: string[];
   draftLeaks: string[];
+  imageAltIssues: string[];
   invalidLegacyRedirects: string[];
+  metadataIssues: string[];
   missingArticleJsonLd: string[];
   missingLegacyRedirects: string[];
   missingRequired: string[];
@@ -239,74 +242,38 @@ export function formatBuildVerificationReport(
   }
 
   const lines = ["Build verification failed."];
+  const sections: Array<[string, readonly string[], number?]> = [
+    ["Article PDF issues", result.issues.articlePdfIssues, 50],
+    ["Missing", result.issues.missingRequired],
+    ["Missing legacy redirects", result.issues.missingLegacyRedirects, 50],
+    ["Invalid legacy redirects", result.issues.invalidLegacyRedirects, 50],
+    ["Metadata issues", result.issues.metadataIssues, 50],
+    ["Image alt issues", result.issues.imageAltIssues, 50],
+    ["Broken links", result.issues.brokenLinks, 50],
+    ["Unexpected component catalog output", result.issues.catalogLeaks],
+    ["Article count mismatch", result.issues.articleCountIssues],
+    [
+      "Unexpected static-page client scripts",
+      result.issues.unexpectedClientScripts,
+    ],
+    ["Unexpected generated dated pages", result.issues.unexpectedDatedPages],
+    ["Draft content leaked into generated metadata", result.issues.draftLeaks],
+    ["Missing article JSON-LD", result.issues.missingArticleJsonLd, 50],
+    ["Unexpected source maps", result.issues.sourceMaps, 50],
+    ["Social preview image issues", result.issues.socialImageIssues, 50],
+    [
+      "Unexpected hydration boundaries",
+      result.issues.unexpectedHydrationBoundaries,
+      50,
+    ],
+  ];
 
-  if (result.issues.articlePdfIssues.length > 0) {
-    lines.push(
-      `Article PDF issues: ${JSON.stringify(result.issues.articlePdfIssues.slice(0, 50))}`,
-    );
-  }
-  if (result.issues.missingRequired.length > 0) {
-    lines.push(`Missing: ${JSON.stringify(result.issues.missingRequired)}`);
-  }
-  if (result.issues.missingLegacyRedirects.length > 0) {
-    lines.push(
-      `Missing legacy redirects: ${JSON.stringify(result.issues.missingLegacyRedirects.slice(0, 50))}`,
-    );
-  }
-  if (result.issues.invalidLegacyRedirects.length > 0) {
-    lines.push(
-      `Invalid legacy redirects: ${JSON.stringify(result.issues.invalidLegacyRedirects.slice(0, 50))}`,
-    );
-  }
-  if (result.issues.brokenLinks.length > 0) {
-    lines.push(
-      `Broken links: ${JSON.stringify(result.issues.brokenLinks.slice(0, 50))}`,
-    );
-  }
-  if (result.issues.catalogLeaks.length > 0) {
-    lines.push(
-      `Unexpected component catalog output: ${JSON.stringify(result.issues.catalogLeaks)}`,
-    );
-  }
-  if (result.issues.articleCountIssues.length > 0) {
-    lines.push(
-      `Article count mismatch: ${JSON.stringify(result.issues.articleCountIssues)}`,
-    );
-  }
-  if (result.issues.unexpectedClientScripts.length > 0) {
-    lines.push(
-      `Unexpected static-page client scripts: ${JSON.stringify(result.issues.unexpectedClientScripts)}`,
-    );
-  }
-  if (result.issues.unexpectedDatedPages.length > 0) {
-    lines.push(
-      `Unexpected generated dated pages: ${JSON.stringify(result.issues.unexpectedDatedPages)}`,
-    );
-  }
-  if (result.issues.draftLeaks.length > 0) {
-    lines.push(
-      `Draft content leaked into generated metadata: ${JSON.stringify(result.issues.draftLeaks)}`,
-    );
-  }
-  if (result.issues.missingArticleJsonLd.length > 0) {
-    lines.push(
-      `Missing article JSON-LD: ${JSON.stringify(result.issues.missingArticleJsonLd.slice(0, 50))}`,
-    );
-  }
-  if (result.issues.sourceMaps.length > 0) {
-    lines.push(
-      `Unexpected source maps: ${JSON.stringify(result.issues.sourceMaps.slice(0, 50))}`,
-    );
-  }
-  if (result.issues.socialImageIssues.length > 0) {
-    lines.push(
-      `Social preview image issues: ${JSON.stringify(result.issues.socialImageIssues.slice(0, 50))}`,
-    );
-  }
-  if (result.issues.unexpectedHydrationBoundaries.length > 0) {
-    lines.push(
-      `Unexpected hydration boundaries: ${JSON.stringify(result.issues.unexpectedHydrationBoundaries.slice(0, 50))}`,
-    );
+  for (const [label, values, limit] of sections) {
+    if (values.length > 0) {
+      lines.push(
+        `${label}: ${JSON.stringify(limit === undefined ? values : values.slice(0, limit))}`,
+      );
+    }
   }
 
   return lines.join("\n");
@@ -654,6 +621,10 @@ export async function verifyBuild({
       await inspectFeedEnclosures(distDir, file, issues);
     }
 
+    if (/\/?sitemap-\d+\.xml$/u.test(toPosix(path.relative(distDir, file)))) {
+      await inspectSitemapPolicy(distDir, file, issues);
+    }
+
     await inspectDraftLeaks(distDir, file, draftSlugs, issues);
   }
 
@@ -772,6 +743,8 @@ function emptyIssues(): BuildVerificationIssues {
     catalogLeaks: [],
     draftLeaks: [],
     invalidLegacyRedirects: [],
+    imageAltIssues: [],
+    metadataIssues: [],
     missingArticleJsonLd: [],
     missingLegacyRedirects: [],
     missingRequired: [],
@@ -825,6 +798,8 @@ function hasIssues(issues: BuildVerificationIssues): boolean {
     issues.catalogLeaks.length > 0 ||
     issues.draftLeaks.length > 0 ||
     issues.invalidLegacyRedirects.length > 0 ||
+    issues.imageAltIssues.length > 0 ||
+    issues.metadataIssues.length > 0 ||
     issues.missingArticleJsonLd.length > 0 ||
     issues.missingLegacyRedirects.length > 0 ||
     issues.missingRequired.length > 0 ||
@@ -932,6 +907,35 @@ async function inspectFeedEnclosures(
   }
 }
 
+async function inspectSitemapPolicy(
+  distDir: string,
+  file: string,
+  issues: BuildVerificationIssues,
+): Promise<void> {
+  const xml = await readFile(file, "utf8");
+  const relativePath = toPosix(path.relative(distDir, file));
+  const locPattern = /<loc>([^<]+)<\/loc>/giu;
+  let match: null | RegExpExecArray;
+
+  while ((match = locPattern.exec(xml)) !== null) {
+    const loc = match[1];
+    if (loc === undefined) {
+      continue;
+    }
+
+    const pathname = absoluteUrlPathname(loc);
+    if (pathname === undefined) {
+      issues.metadataIssues.push(
+        `${relativePath}: sitemap contains invalid URL ${loc}`,
+      );
+    } else if (!sitemapIncludesPath(pathname)) {
+      issues.metadataIssues.push(
+        `${relativePath}: sitemap includes noindex route ${pathname}`,
+      );
+    }
+  }
+}
+
 function metaContentValues(html: string, metaName: string): string[] {
   return metaContentValuesByAttribute(html, "name", metaName);
 }
@@ -1019,11 +1023,35 @@ function localGeneratedSocialImagePath(
   return path.join(distDir, decodeURIComponent(pathname.slice(1)));
 }
 
+/**
+ * Extracts an absolute URL pathname without constructing a mutable URL object.
+ *
+ * @param value Absolute URL string.
+ * @returns URL pathname, or `undefined` for non-absolute input.
+ */
 function absoluteUrlPathname(value: string): string | undefined {
-  const match = /^[a-z][a-z\d+.-]*:\/\/[^/?#]+(?<pathname>\/[^?#]*)/iu.exec(
-    value,
+  const authoritySeparator = value.indexOf("://");
+  if (authoritySeparator <= 0) {
+    return undefined;
+  }
+
+  const pathStart = value.indexOf("/", authoritySeparator + 3);
+  if (pathStart === -1) {
+    return "/";
+  }
+
+  const queryStart = value.indexOf("?", pathStart);
+  const hashStart = value.indexOf("#", pathStart);
+  const pathEndCandidates = [queryStart, hashStart].filter(
+    (index) => index >= 0,
   );
-  return match?.groups?.["pathname"];
+  const pathEnd =
+    pathEndCandidates.length === 0
+      ? value.length
+      : Math.min(...pathEndCandidates);
+
+  const pathname = value.slice(pathStart, pathEnd);
+  return pathname === "" ? "/" : pathname;
 }
 
 function htmlAttributeValue(
@@ -1077,6 +1105,141 @@ function scholarPdfMetaMatches(value: string, pdfHref: string): boolean {
   return pathname === pdfHref;
 }
 
+function inspectHtmlMetadata(
+  html: string,
+  relativeHtmlPath: string,
+  issues: BuildVerificationIssues,
+): void {
+  const title = htmlTitleText(html);
+  const canonicalLinks = htmlTags(html, "link").filter(
+    (tag) => htmlAttributeValue(tag, "rel") === "canonical",
+  );
+  const description = metaContentValues(html, "description")[0];
+  const robots = metaContentValues(html, "robots")[0];
+  const jsonLdScripts = htmlScriptTextsByType(html, "application/ld+json");
+
+  if (title === "") {
+    issues.metadataIssues.push(`${relativeHtmlPath}: missing document title`);
+  }
+
+  if (canonicalLinks.length !== 1) {
+    issues.metadataIssues.push(
+      `${relativeHtmlPath}: expected exactly one canonical link, found ${canonicalLinks.length}`,
+    );
+  } else if (
+    htmlAttributeValue(canonicalLinks[0] ?? "", "href")?.trim() === ""
+  ) {
+    issues.metadataIssues.push(`${relativeHtmlPath}: canonical link is empty`);
+  }
+
+  if (description === undefined || description.trim() === "") {
+    issues.metadataIssues.push(`${relativeHtmlPath}: missing meta description`);
+  }
+
+  if (robots === undefined || robots.trim() === "") {
+    issues.metadataIssues.push(`${relativeHtmlPath}: missing robots policy`);
+  }
+
+  if (jsonLdScripts.length === 0) {
+    issues.metadataIssues.push(`${relativeHtmlPath}: missing JSON-LD`);
+  }
+
+  for (const script of jsonLdScripts) {
+    try {
+      JSON.parse(script.trim());
+    } catch {
+      issues.metadataIssues.push(`${relativeHtmlPath}: invalid JSON-LD script`);
+    }
+  }
+
+  inspectHtmlImageAlt(html, relativeHtmlPath, issues);
+
+  if (robots !== undefined && !robots.includes("noindex")) {
+    inspectShareableHtmlMetadata(html, relativeHtmlPath, issues);
+  }
+}
+
+function inspectHtmlImageAlt(
+  html: string,
+  relativeHtmlPath: string,
+  issues: BuildVerificationIssues,
+): void {
+  htmlTags(html, "img").forEach((image, index) => {
+    const role = htmlAttributeValue(image, "role");
+    const isDecorative =
+      htmlAttributeValue(image, "aria-hidden") === "true" ||
+      role === "presentation" ||
+      role === "none";
+
+    if (!isDecorative && htmlAttributeValue(image, "alt") === undefined) {
+      const src = htmlAttributeValue(image, "src") ?? `image ${index + 1}`;
+      issues.imageAltIssues.push(`${relativeHtmlPath}: ${src} is missing alt`);
+    }
+  });
+}
+
+function inspectShareableHtmlMetadata(
+  html: string,
+  relativeHtmlPath: string,
+  issues: BuildVerificationIssues,
+): void {
+  const requiredMeta = [
+    ["property", "og:site_name"],
+    ["property", "og:locale"],
+    ["property", "og:type"],
+    ["property", "og:title"],
+    ["property", "og:description"],
+    ["property", "og:url"],
+    ["property", "og:image"],
+    ["name", "twitter:card"],
+    ["name", "twitter:title"],
+    ["name", "twitter:description"],
+    ["name", "twitter:image"],
+  ] as const;
+
+  for (const [attributeName, attributeValue] of requiredMeta) {
+    const value =
+      attributeName === "name"
+        ? metaContentValues(html, attributeValue)[0]
+        : metaPropertyContentValues(html, attributeValue)[0];
+    if (value === undefined || value.trim() === "") {
+      issues.metadataIssues.push(
+        `${relativeHtmlPath}: missing ${attributeName}="${attributeValue}" metadata`,
+      );
+    }
+  }
+}
+
+function htmlScriptTextsByType(html: string, type: string): string[] {
+  const texts: string[] = [];
+  const scriptPattern = /<script(?<attributes>[^>]*)>([\s\S]*?)<\/script>/giu;
+  let match: null | RegExpExecArray;
+
+  while ((match = scriptPattern.exec(html)) !== null) {
+    const attributes = match.groups?.["attributes"];
+    if (
+      attributes !== undefined &&
+      htmlAttributeValue(`<script${attributes}>`, "type") === type
+    ) {
+      texts.push(match[2] ?? "");
+    }
+  }
+
+  return texts;
+}
+
+function htmlTags(html: string, tagName: "img" | "link"): string[] {
+  const tagPattern = tagName === "img" ? /<img\b[^>]*>/giu : /<link\b[^>]*>/giu;
+
+  return Array.from(html.matchAll(tagPattern), (match) => match[0]);
+}
+
+function htmlTitleText(html: string): string {
+  const titleMatch = /<title\b[^>]*>([\s\S]*?)<\/title>/iu.exec(html);
+
+  return decodeHtmlAttributeValue(titleMatch?.[1]?.trim() ?? "");
+}
+
 async function inspectHtmlFile(
   distDir: string,
   file: string,
@@ -1114,6 +1277,8 @@ async function inspectHtmlFile(
 
     return;
   }
+
+  inspectHtmlMetadata(text, relativeHtmlPath, issues);
 
   if (
     isArticleHtmlPath(relativeHtmlPath) &&

--- a/scripts/build/verify-build.ts
+++ b/scripts/build/verify-build.ts
@@ -971,40 +971,68 @@ function metaContentValuesByAttribute(
 
 function articleJsonLdImageValues(html: string): string[] {
   const values: string[] = [];
-  const scriptPattern = /<script(?<attributes>[^>]*)>([\s\S]*?)<\/script>/giu;
-  let match: null | RegExpExecArray;
 
-  while ((match = scriptPattern.exec(html)) !== null) {
-    const attributes = match.groups?.["attributes"];
-    if (
-      attributes === undefined ||
-      htmlAttributeValue(`<script${attributes}>`, "type") !==
-        "application/ld+json"
-    ) {
-      continue;
+  for (const node of articleJsonLdNodes(html)) {
+    const image = node["image"];
+    if (typeof image === "string") {
+      values.push(image);
     }
+  }
 
-    const text = match[2]?.trim();
-    if (text === undefined || text === "") {
+  return values;
+}
+
+function articleJsonLdNodes(html: string): Array<Record<string, unknown>> {
+  return jsonLdNodesByType(html, "BlogPosting");
+}
+
+function jsonLdNodesByType(
+  html: string,
+  type: string,
+): Array<Record<string, unknown>> {
+  const nodes: Array<Record<string, unknown>> = [];
+
+  for (const script of htmlScriptTextsByType(html, "application/ld+json")) {
+    const text = script.trim();
+    if (text === "") {
       continue;
     }
 
     try {
       const parsed = JSON.parse(text) as unknown;
-      if (!isRecord(parsed) || parsed["@type"] !== "BlogPosting") {
-        continue;
-      }
-
-      const image = parsed["image"];
-      if (typeof image === "string") {
-        values.push(image);
+      for (const node of jsonLdNodeCandidates(parsed)) {
+        if (jsonLdTypeIncludes(node["@type"], type)) {
+          nodes.push(node);
+        }
       }
     } catch {
-      // Invalid JSON-LD is reported by the missing/mismatched image checks.
+      // Invalid JSON-LD is reported by the generic metadata verifier.
     }
   }
 
-  return values;
+  return nodes;
+}
+
+function jsonLdNodeCandidates(value: unknown): Array<Record<string, unknown>> {
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  const candidates = [value];
+  const graph = value["@graph"];
+  if (Array.isArray(graph)) {
+    candidates.push(...graph.filter(isRecord));
+  }
+
+  return candidates;
+}
+
+function jsonLdTypeIncludes(value: unknown, type: string): boolean {
+  return (
+    value === type ||
+    (Array.isArray(value) &&
+      value.some((entry) => typeof entry === "string" && entry === type))
+  );
 }
 
 function localGeneratedSocialImagePath(
@@ -1282,7 +1310,7 @@ async function inspectHtmlFile(
 
   if (
     isArticleHtmlPath(relativeHtmlPath) &&
-    !text.includes('"@type":"BlogPosting"')
+    articleJsonLdNodes(text).length === 0
   ) {
     issues.missingArticleJsonLd.push(relativeHtmlPath);
   }

--- a/scripts/quality/verify-platform-boundaries.ts
+++ b/scripts/quality/verify-platform-boundaries.ts
@@ -107,6 +107,7 @@ const libDomainFiles = {
     "metadata.ts",
     "navigation.ts",
     "routes.ts",
+    "semantic-metadata.ts",
     "seo.ts",
     "share-targets.ts",
     "site-config-defaults.ts",

--- a/scripts/quality/verify-platform-boundaries.ts
+++ b/scripts/quality/verify-platform-boundaries.ts
@@ -104,6 +104,7 @@ const libDomainFiles = {
   ],
   "routes-and-features": [
     "feature-routes.ts",
+    "metadata.ts",
     "navigation.ts",
     "routes.ts",
     "seo.ts",

--- a/site/README.md
+++ b/site/README.md
@@ -108,6 +108,10 @@ Only `title`, `description`, `date`, and `author` are required for a normal
 article. Tags and images are strongly recommended when they help readers find
 or understand the article.
 
+Use `updated` only when a published article has a meaningful revision that
+readers and search engines should know about. Do not change it for typo fixes,
+formatting-only edits, or build/tooling changes.
+
 Do not add `slug` or `category` fields. The filename becomes the slug. The
 folder becomes the category.
 
@@ -118,6 +122,7 @@ folder becomes the category.
 | `title`       | The article title shown on the page.                                   |
 | `description` | A short summary used in previews, search, RSS, and metadata.           |
 | `date`        | Publication date. Use `YYYY-MM-DD` unless a maintainer asks otherwise. |
+| `updated`     | Optional meaningful update date. Use only for substantive revisions.   |
 | `author`      | Must match an author name or alias in `content/authors/`.              |
 | `tags`        | Optional grouping labels. They become clickable tag pages.             |
 | `image`       | Optional preview image for article lists and social previews.          |
@@ -276,6 +281,7 @@ title: "Forum Update"
 description: "A short summary of the announcement."
 date: 2026-05-01
 author: "The Philosopher's Meme"
+updated: 2026-05-02
 tags: []
 ---
 
@@ -284,6 +290,9 @@ Announcement body starts here.
 
 Announcements appear on the announcements page, can appear in RSS, and the
 newest homepage-visible announcements appear on the homepage.
+
+The optional `updated` field works the same way as article `updated`: use it
+only for substantive changes to a published announcement.
 
 Use `visibility` if an announcement should have a direct link but stay out of
 homepage, RSS, search, or directory lists:
@@ -454,12 +463,18 @@ site/config/site.json
 Common things a webmaster might change there:
 
 - site title and description;
+- site identity metadata such as language, locale, publisher type, logo,
+  theme color, and official social profiles;
 - primary and footer navigation links;
 - homepage labels, discovery links, empty-state text, and list limits;
 - support links;
 - share-menu targets and social handles;
 - feature switches;
 - default visibility and PDF behavior.
+
+The `identity.sameAs` list should contain only official public profiles for
+the site or publication. These links are used for machine-readable publisher
+metadata and social/SEO context, not as ordinary footer links.
 
 Most omitted optional fields have safe defaults. For example, articles and
 announcements are visible in directories, search, RSS, and homepage surfaces by

--- a/site/README.md
+++ b/site/README.md
@@ -130,6 +130,7 @@ folder becomes the category.
 | `draft`       | Set `draft: true` to keep an entry unpublished.                        |
 | `pdf`         | Articles default to PDF export. Set `pdf: false` only for exceptions.  |
 | `visibility`  | Optional controls for where a published entry appears. See below.      |
+| `semantic`    | Optional special metadata for reviews, events, media, datasets, etc.   |
 
 Tags should be lowercase, trimmed, and unique. Do not use `/` in tags.
 
@@ -182,6 +183,97 @@ What each option means:
 
 You can set only the values you need. Omitted values use the defaults from
 `config/site.json`.
+
+## Special Semantic Metadata
+
+Most articles and announcements do not need this section.
+
+Use `semantic` only when the page is clearly a special kind of content, such as
+a review, event, video, audio work, book, dataset, software project, or FAQ.
+The site uses this information in two ways:
+
+- it shows a small visible details block on the page;
+- it adds machine-readable metadata for search engines, social tools, and other
+  software.
+
+Only add facts that are also true and visible to readers. Do not use
+`semantic` just to add hidden search keywords.
+
+### Review Example
+
+```yaml
+semantic:
+  kind: review
+  item:
+    type: book
+    name: "Example Book"
+    author: "Example Author"
+    url: "https://example.com/book"
+  rating:
+    value: 4
+    best: 5
+  summary: "A short visible summary of what is being reviewed."
+```
+
+The reviewed item `type` can be:
+
+- `article`
+- `audio`
+- `book`
+- `creative-work`
+- `dataset`
+- `event`
+- `software`
+- `video`
+
+The rating is optional. If there is no clear rating, leave it out.
+
+### Event Example
+
+```yaml
+semantic:
+  kind: event
+  name: "TPM Reading Group"
+  startDate: 2026-06-01T19:00:00-04:00
+  attendance: online
+  location:
+    type: online
+    url: "https://example.com/live"
+```
+
+Use events only for real events with a clear date or time. If the page only
+mentions an event in passing, do not add event metadata.
+
+### Media, Book, Dataset, Software, And FAQ Examples
+
+```yaml
+semantic:
+  kind: video
+  name: "Interview Title"
+  url: "https://example.com/video"
+  embedUrl: "https://example.com/embed/video"
+  uploadDate: 2026-06-01
+```
+
+```yaml
+semantic:
+  kind: dataset
+  name: "Example Meme Dataset"
+  description: "A short description of the dataset."
+  url: "https://example.com/dataset"
+  license: "https://creativecommons.org/licenses/by/4.0/"
+```
+
+```yaml
+semantic:
+  kind: faq
+  items:
+    - question: "Who is this for?"
+      answer: "Readers who want a concise answer visible on the page."
+```
+
+Ask a maintainer before using `semantic` if you are unsure. It is better to
+omit this metadata than to publish inaccurate structured data.
 
 ## Write The Article Body
 

--- a/site/README.md
+++ b/site/README.md
@@ -23,7 +23,10 @@ For a slower step-by-step article walkthrough, see
   share settings, feature switches, and defaults.
 - `theme.css`: site colors, fonts, radius, and visual theme tokens.
 - `public/`: files copied directly to the site root, such as favicons,
-  `robots.txt`, and `CNAME`.
+  `robots.txt`, `CNAME`, `_headers`, and well-known compatibility files.
+  `_headers` is a Cloudflare deployment file; it should stay scoped to static
+  platform concerns such as immutable caching for hashed `_astro` assets and
+  MIME types for well-known files.
 - `unused-assets/`: old assets kept for reference. Do not link to files from
   this folder in new content.
 

--- a/site/config/redirects.json
+++ b/site/config/redirects.json
@@ -1,4 +1,12 @@
 {
+  "/aesthetics/": "/categories/aesthetics/",
+  "/game-studies/": "/categories/game-studies/",
+  "/history/": "/categories/history/",
+  "/irony/": "/categories/irony/",
+  "/memeculture/": "/categories/memeculture/",
+  "/metamemetics/": "/categories/metamemetics/",
+  "/philosophy/": "/categories/philosophy/",
+  "/politics/": "/categories/politics/",
   "/2015/06/18/tmnh/": "/articles/tmnh/",
   "/2015/08/19/misattributed-plato-quote-is-real-now/": "/articles/misattributed-plato-quote-is-real-now/",
   "/2015/09/14/a-short-note-on-the-death-of-pepe/": "/articles/a-short-note-on-the-death-of-pepe/",

--- a/site/config/site.json
+++ b/site/config/site.json
@@ -80,8 +80,20 @@
   "identity": {
     "description": "The philosophy of memes, cyberculture, and the Internet.",
     "language": "en",
+    "locale": "en_US",
+    "logo": "/favicon.svg?v=2",
     "publisherName": "The Philosopher's Meme",
+    "publisherType": "organization",
+    "sameAs": [
+      "https://x.com/philo_meme",
+      "https://www.instagram.com/the_philosophers_meme",
+      "https://www.facebook.com/thephilosophersmeme",
+      "https://www.tiktok.com/@thephilosophersmeme",
+      "https://www.threads.com/@the_philosophers_meme",
+      "https://www.youtube.com/thephilosophersmeme"
+    ],
     "shortTitle": "TPM",
+    "themeColor": "#b65a35",
     "timezone": "America/New_York",
     "title": "The Philosopher's Meme",
     "url": "https://thephilosophersmeme.com"

--- a/site/config/site.schema.json
+++ b/site/config/site.schema.json
@@ -417,13 +417,39 @@
           "type": "string",
           "minLength": 2
         },
+        "locale": {
+          "default": "en_US",
+          "type": "string",
+          "minLength": 2
+        },
+        "logo": {
+          "type": "string",
+          "minLength": 1
+        },
         "publisherName": {
           "type": "string",
           "minLength": 1
         },
+        "publisherType": {
+          "default": "organization",
+          "type": "string",
+          "enum": ["organization", "person"]
+        },
+        "sameAs": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
         "shortTitle": {
           "type": "string",
           "minLength": 1
+        },
+        "themeColor": {
+          "type": "string",
+          "pattern": "^#[\\da-f]{6}$"
         },
         "timezone": {
           "type": "string",

--- a/site/public/.well-known/traffic-advice
+++ b/site/public/.well-known/traffic-advice
@@ -1,0 +1,3 @@
+[
+  { "user_agent": "prefetch-proxy", "fraction": 1 }
+]

--- a/site/public/_headers
+++ b/site/public/_headers
@@ -1,0 +1,6 @@
+/_astro/*
+  Cache-Control: public, max-age=31556952, immutable
+
+/.well-known/traffic-advice
+  Content-Type: application/trafficadvice+json; charset=utf-8
+  X-Content-Type-Options: nosniff

--- a/src/catalog/catalog.config.ts
+++ b/src/catalog/catalog.config.ts
@@ -98,6 +98,12 @@ export const componentCatalogIgnoreList = [
   },
   {
     lifecycle: "route-only",
+    path: "src/components/articles/SemanticDetails.astro",
+    reason:
+      "Internal article-header semantic metadata surface covered by SemanticDetails and ArticleHeader tests.",
+  },
+  {
+    lifecycle: "route-only",
     path: "src/components/articles/ArticleShareActionRow.astro",
     reason:
       "Internal article-share row renderer covered by ArticleShareMenu examples and component tests.",

--- a/src/catalog/catalog.config.ts
+++ b/src/catalog/catalog.config.ts
@@ -167,6 +167,18 @@ export const componentCatalogIgnoreList = [
   },
   {
     lifecycle: "route-only",
+    path: "src/components/seo/AnnouncementJsonLd.astro",
+    reason:
+      "Non-visual announcement metadata component covered by SEO component and page render tests.",
+  },
+  {
+    lifecycle: "route-only",
+    path: "src/components/seo/PublishableOpenGraphMeta.astro",
+    reason:
+      "Non-visual Open Graph metadata component covered by SEO component and article render tests.",
+  },
+  {
+    lifecycle: "route-only",
     path: "src/components/seo/SiteHead.astro",
     reason: "Non-visual SEO component covered by SEO and page render tests.",
   },

--- a/src/components/articles/ArticleHeader.astro
+++ b/src/components/articles/ArticleHeader.astro
@@ -6,10 +6,12 @@ import ArticleHeaderActionLink from "./ArticleHeaderActionLink.astro";
 import ArticleHeaderActionRow from "./ArticleHeaderActionRow.astro";
 import ArticleMeta from "./ArticleMeta.astro";
 import ArticleShareMenu from "./ArticleShareMenu.astro";
+import SemanticDetails from "./SemanticDetails.astro";
 import TextLink from "../ui/TextLink.astro";
 import type { AuthorSummary } from "../../lib/authors";
 import type { ArticlePdfViewModel } from "../../lib/article-pdf";
 import type { ArticleCitationMenuViewModel } from "../../lib/citations/article-citation";
+import type { SemanticDetailsViewModel } from "../../lib/semantic-metadata";
 import type { ArticleShareMenuViewModel } from "../../lib/share-targets";
 
 interface ArticleCategory {
@@ -27,6 +29,7 @@ interface Props {
   formattedDate?: string | undefined;
   pdf?: ArticlePdfViewModel | undefined;
   profileLinksEnabled?: boolean | undefined;
+  semanticDetails?: SemanticDetailsViewModel | undefined;
   share?: ArticleShareMenuViewModel | undefined;
   title: string;
 }
@@ -41,6 +44,7 @@ const {
   formattedDate,
   pdf,
   profileLinksEnabled = true,
+  semanticDetails,
   share,
   title,
 } = Astro.props;
@@ -116,6 +120,7 @@ const hasKickerRow = category !== undefined || hasHeaderActions;
       </p>
     )
   }
+  <SemanticDetails details={semanticDetails} />
   {
     pdf && (
       <>

--- a/src/components/articles/HoverImageCard.astro
+++ b/src/components/articles/HoverImageCard.astro
@@ -74,6 +74,8 @@ function aspectRatioOrFallback(image: ImageMetadata): number {
       <Image
         src={image}
         alt={alt}
+        aria-hidden={alt === "" ? "true" : undefined}
+        role={alt === "" ? "presentation" : undefined}
         format="webp"
         widths={previewWidths.length > 0 ? previewWidths : [optimizedWidth]}
         sizes={`${displayWidthRem.toFixed(3)}rem`}

--- a/src/components/articles/SemanticDetails.astro
+++ b/src/components/articles/SemanticDetails.astro
@@ -1,0 +1,51 @@
+---
+import TextLink from "../ui/TextLink.astro";
+import type { SemanticDetailsViewModel } from "../../lib/semantic-metadata";
+
+interface Props {
+  details?: SemanticDetailsViewModel | undefined;
+}
+
+const { details } = Astro.props;
+---
+
+{
+  details && details.items.length > 0 && (
+    <aside
+      class="border-border max-w-4xl min-w-0 border-y py-3 text-sm"
+      aria-label={details.heading}
+      data-semantic-details
+    >
+      <div class="grid min-w-0 gap-3">
+        <div class="grid min-w-0 gap-1">
+          <h2 class="text-foreground m-0 text-base font-semibold tracking-normal">
+            {details.heading}
+          </h2>
+          {details.description && (
+            <p class="text-muted-foreground m-0 leading-6">
+              {details.description}
+            </p>
+          )}
+        </div>
+        <dl class="grid min-w-0 gap-x-6 gap-y-2 sm:grid-cols-2">
+          {details.items.map((item) => (
+            <div class="grid min-w-0 gap-0.5">
+              <dt class="text-muted-foreground text-xs font-medium tracking-normal uppercase">
+                {item.label}
+              </dt>
+              <dd class="text-foreground m-0 min-w-0 break-words">
+                {item.href ? (
+                  <TextLink href={item.href} prefetch={false}>
+                    {item.value}
+                  </TextLink>
+                ) : (
+                  item.value
+                )}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </aside>
+  )
+}

--- a/src/components/seo/AnnouncementJsonLd.astro
+++ b/src/components/seo/AnnouncementJsonLd.astro
@@ -1,6 +1,8 @@
 ---
 import type { AnnouncementEntry } from "../../lib/routes";
 import { announcementUrl } from "../../lib/routes";
+import { jsonLdGraph } from "../../lib/metadata";
+import { semanticMetadataJsonLd } from "../../lib/semantic-metadata";
 import { publishableBlogPostingJsonLd, safeJsonLd } from "../../lib/seo";
 import type { SocialPreviewImage } from "../../lib/social-images";
 
@@ -10,13 +12,31 @@ interface Props {
 }
 
 const { announcement, image } = Astro.props;
-const jsonLd = safeJsonLd(
-  publishableBlogPostingJsonLd(announcement, Astro.site, {
+const canonicalPath = announcementUrl(announcement.id);
+const semanticJsonLd = semanticMetadataJsonLd(announcement.data.semantic, {
+  authorName: announcement.data.author,
+  canonicalPath,
+  datePublished: announcement.data.date,
+  site: Astro.site,
+});
+const announcementJsonLd = publishableBlogPostingJsonLd(
+  announcement,
+  Astro.site,
+  {
+    about: semanticJsonLd.references,
     canonicalPath: announcementUrl(announcement.id),
     fallbackAuthorName: announcement.data.author,
     image: image?.src,
     section: "Announcements",
-  }),
+  },
+);
+const announcementJsonLdWithoutContext = Object.fromEntries(
+  Object.entries(announcementJsonLd).filter(([key]) => key !== "@context"),
+);
+const jsonLd = safeJsonLd(
+  semanticJsonLd.nodes.length === 0
+    ? announcementJsonLd
+    : jsonLdGraph([announcementJsonLdWithoutContext, ...semanticJsonLd.nodes]),
 );
 ---
 

--- a/src/components/seo/AnnouncementJsonLd.astro
+++ b/src/components/seo/AnnouncementJsonLd.astro
@@ -1,0 +1,23 @@
+---
+import type { AnnouncementEntry } from "../../lib/routes";
+import { announcementUrl } from "../../lib/routes";
+import { publishableBlogPostingJsonLd, safeJsonLd } from "../../lib/seo";
+import type { SocialPreviewImage } from "../../lib/social-images";
+
+interface Props {
+  announcement: AnnouncementEntry;
+  image?: SocialPreviewImage | undefined;
+}
+
+const { announcement, image } = Astro.props;
+const jsonLd = safeJsonLd(
+  publishableBlogPostingJsonLd(announcement, Astro.site, {
+    canonicalPath: announcementUrl(announcement.id),
+    fallbackAuthorName: announcement.data.author,
+    image: image?.src,
+    section: "Announcements",
+  }),
+);
+---
+
+<script is:inline type="application/ld+json" set:html={jsonLd} />

--- a/src/components/seo/ArticleJsonLd.astro
+++ b/src/components/seo/ArticleJsonLd.astro
@@ -1,6 +1,9 @@
 ---
 import type { ArticleEntry, CategorySummary } from "../../lib/routes";
+import { articleUrl, authorName } from "../../lib/routes";
 import type { AuthorSummary } from "../../lib/authors";
+import { jsonLdGraph } from "../../lib/metadata";
+import { semanticMetadataJsonLd } from "../../lib/semantic-metadata";
 import { articleBlogPostingJsonLd, safeJsonLd } from "../../lib/seo";
 import type { SocialPreviewImage } from "../../lib/social-images";
 
@@ -12,10 +15,29 @@ interface Props {
 }
 
 const { article, authors = [], category, image } = Astro.props;
-const jsonLd = safeJsonLd(
-  articleBlogPostingJsonLd(article, category, Astro.site, authors, {
+const semanticJsonLd = semanticMetadataJsonLd(article.data.semantic, {
+  authorName: authorName(article),
+  canonicalPath: articleUrl(article.id),
+  datePublished: article.data.date,
+  site: Astro.site,
+});
+const articleJsonLd = articleBlogPostingJsonLd(
+  article,
+  category,
+  Astro.site,
+  authors,
+  {
+    about: semanticJsonLd.references,
     image: image?.src,
-  }),
+  },
+);
+const articleJsonLdWithoutContext = Object.fromEntries(
+  Object.entries(articleJsonLd).filter(([key]) => key !== "@context"),
+);
+const jsonLd = safeJsonLd(
+  semanticJsonLd.nodes.length === 0
+    ? articleJsonLd
+    : jsonLdGraph([articleJsonLdWithoutContext, ...semanticJsonLd.nodes]),
 );
 ---
 

--- a/src/components/seo/ArticleScholarMeta.astro
+++ b/src/components/seo/ArticleScholarMeta.astro
@@ -9,15 +9,27 @@ const { metadata } = Astro.props;
 ---
 
 <meta name="citation_title" content={metadata.title} />
+<meta name="citation_language" content={metadata.language} />
+<meta name="citation_abstract" content={metadata.abstract} />
 {
   metadata.authors.map((author) => (
     <meta name="citation_author" content={author} />
   ))
 }
+{
+  metadata.keywords.length > 0 && (
+    <meta name="citation_keywords" content={metadata.keywords.join("; ")} />
+  )
+}
 <meta
   name="citation_publication_date"
   content={metadata.publicationDateForScholar}
 />
+{
+  metadata.references.map((reference) => (
+    <meta name="citation_reference" content={reference} />
+  ))
+}
 {
   metadata.pdf && (
     <meta name="citation_pdf_url" content={metadata.pdf.citationPdfUrl} />

--- a/src/components/seo/PublishableOpenGraphMeta.astro
+++ b/src/components/seo/PublishableOpenGraphMeta.astro
@@ -1,0 +1,21 @@
+---
+interface Props {
+  author: string;
+  publishedAt: Date;
+  section?: string | undefined;
+  tags?: readonly string[] | undefined;
+  updatedAt?: Date | undefined;
+}
+
+const { author, publishedAt, section, tags = [], updatedAt } = Astro.props;
+---
+
+<meta property="article:published_time" content={publishedAt.toISOString()} />
+{
+  updatedAt && (
+    <meta property="article:modified_time" content={updatedAt.toISOString()} />
+  )
+}
+{section && <meta property="article:section" content={section} />}
+<meta property="article:author" content={author} />
+{tags.map((tag) => <meta property="article:tag" content={tag} />)}

--- a/src/components/seo/SiteHead.astro
+++ b/src/components/seo/SiteHead.astro
@@ -1,40 +1,68 @@
 ---
 import type { SocialPreviewImage } from "../../lib/social-images";
-import { absoluteUrl } from "../../lib/seo";
+import { absoluteUrl, safeJsonLd } from "../../lib/seo";
 import { feedUrl, SITE_TITLE } from "../../lib/routes";
+import { siteConfig } from "../../lib/site-config";
+import {
+  jsonLdGraph,
+  siteIdentityJsonLd,
+  type JsonLdNode,
+  type RouteMetadata,
+  webPageJsonLd,
+} from "../../lib/metadata";
 
 interface Props {
-  canonicalPath: string;
-  description: string;
   image?: SocialPreviewImage | undefined;
-  title: string;
+  metadata: RouteMetadata;
+  structuredData?: readonly (JsonLdNode | undefined)[] | undefined;
   type?: "website" | "article";
 }
 
-const {
-  canonicalPath,
-  description,
-  image,
-  title,
-  type = "website",
-} = Astro.props;
-const canonicalUrl = absoluteUrl(canonicalPath, Astro.site);
+const { image, metadata, structuredData = [], type = "website" } = Astro.props;
+const canonicalUrl = absoluteUrl(metadata.canonicalPath, Astro.site);
 const absoluteImageUrl =
   image === undefined ? undefined : absoluteUrl(image.src, Astro.site);
+const twitterSite =
+  siteConfig.share.xViaHandle === undefined
+    ? undefined
+    : `@${siteConfig.share.xViaHandle.replace(/^@/u, "")}`;
+const metadataGraph = jsonLdGraph([
+  ...siteIdentityJsonLd(Astro.site),
+  webPageJsonLd(metadata, Astro.site),
+  ...structuredData.filter((node): node is JsonLdNode => node !== undefined),
+]);
+const metadataJsonLd =
+  metadataGraph === undefined ? undefined : safeJsonLd(metadataGraph);
 ---
 
-<meta name="description" content={description} />
-<link rel="canonical" href={canonicalUrl} />
-<link
-  rel="alternate"
-  type="application/rss+xml"
-  title={`${SITE_TITLE} RSS`}
-  href={feedUrl()}
+<meta name="description" content={metadata.description} />
+<meta name="robots" content={metadata.robots} />
+<meta
+  name="application-name"
+  content={siteConfig.identity.shortTitle ?? SITE_TITLE}
 />
+<meta name="color-scheme" content="light dark" />
+{
+  siteConfig.identity.themeColor && (
+    <meta name="theme-color" content={siteConfig.identity.themeColor} />
+  )
+}
+<link rel="canonical" href={canonicalUrl} />
+{
+  siteConfig.features.feed && (
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title={`${SITE_TITLE} RSS`}
+      href={feedUrl()}
+    />
+  )
+}
 <meta property="og:site_name" content={SITE_TITLE} />
+<meta property="og:locale" content={siteConfig.identity.locale} />
 <meta property="og:type" content={type} />
-<meta property="og:title" content={title} />
-<meta property="og:description" content={description} />
+<meta property="og:title" content={metadata.title} />
+<meta property="og:description" content={metadata.description} />
 <meta property="og:url" content={canonicalUrl} />
 {absoluteImageUrl && <meta property="og:image" content={absoluteImageUrl} />}
 {image && <meta property="og:image:width" content={image.width.toString()} />}
@@ -45,8 +73,14 @@ const absoluteImageUrl =
   name="twitter:card"
   content={absoluteImageUrl ? "summary_large_image" : "summary"}
 />
-<meta name="twitter:title" content={title} />
-<meta name="twitter:description" content={description} />
+{twitterSite && <meta name="twitter:site" content={twitterSite} />}
+<meta name="twitter:title" content={metadata.title} />
+<meta name="twitter:description" content={metadata.description} />
 {absoluteImageUrl && <meta name="twitter:image" content={absoluteImageUrl} />}
 {image?.alt && <meta name="twitter:image:alt" content={image.alt} />}
-<title>{title}</title>
+<title>{metadata.title}</title>
+{
+  metadataJsonLd && (
+    <script is:inline type="application/ld+json" set:html={metadataJsonLd} />
+  )
+}

--- a/src/components/ui/BrandButton.astro
+++ b/src/components/ui/BrandButton.astro
@@ -46,6 +46,8 @@ const safeRel = target === "_blank" && rel === undefined ? "noreferrer" : rel;
   <Image
     src={logo}
     alt=""
+    aria-hidden="true"
+    role="presentation"
     layout="fixed"
     loading="eager"
     class:list={[logoClass]}

--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -14,10 +14,12 @@ import ReadingBody from "../components/layout/ReadingBody.astro";
 import ReadingNavigationLinks from "../components/navigation/ReadingNavigationLinks.astro";
 import ArticleJsonLd from "../components/seo/ArticleJsonLd.astro";
 import ArticleScholarMeta from "../components/seo/ArticleScholarMeta.astro";
+import PublishableOpenGraphMeta from "../components/seo/PublishableOpenGraphMeta.astro";
 import type { ArticleReferenceData } from "../lib/article-references/model";
 import type { ArticleTableOfContentsHeading } from "../lib/article-toc";
 import { articlePageViewModel } from "../lib/article-page-view-model";
-import type { ArticleEntry } from "../lib/routes";
+import { breadcrumbListJsonLd } from "../lib/metadata";
+import { articlesIndexUrl, type ArticleEntry } from "../lib/routes";
 import BaseLayout from "./BaseLayout.astro";
 
 interface Props {
@@ -40,6 +42,7 @@ const {
 } = Astro.props;
 const page = await articlePageViewModel({
   article,
+  articleReferences,
   optimizeImage: getImage,
   origin: Astro.url.origin,
   site: Astro.site,
@@ -52,6 +55,21 @@ const page = await articlePageViewModel({
   description={page.article.description}
   canonicalPath={page.article.canonicalPath}
   image={page.socialPreviewImage}
+  kind="article"
+  structuredData={[
+    breadcrumbListJsonLd(
+      page.article.canonicalPath,
+      [
+        { href: "/", title: "Home" },
+        { href: articlesIndexUrl(), title: "Articles" },
+        ...(page.categoryHref && page.category
+          ? [{ href: page.categoryHref, title: page.category.title }]
+          : []),
+        { href: page.article.canonicalPath, title: page.article.title },
+      ],
+      Astro.site,
+    ),
+  ]}
   type="article"
 >
   <ArticleJsonLd
@@ -62,6 +80,14 @@ const page = await articlePageViewModel({
     image={page.socialPreviewImage}
   />
   <ArticleScholarMeta slot="head" metadata={page.scholarMeta} />
+  <PublishableOpenGraphMeta
+    slot="head"
+    author={page.article.author}
+    publishedAt={page.article.date}
+    section={page.category?.title}
+    tags={article.data.tags}
+    updatedAt={article.data.updated}
+  />
   <ReadingBody>
     {
       page.showTableOfContents && (

--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -128,6 +128,7 @@ const page = await articlePageViewModel({
         formattedDate={page.article.formattedDate}
         pdf={page.pdf}
         profileLinksEnabled={page.profileLinksEnabled}
+        semanticDetails={page.semanticDetails}
         share={page.share}
         title={page.article.title}
       />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,17 +3,32 @@ import "../styles/global.css";
 import "@site/theme.css";
 import "../styles/print.css";
 
+import { getImage } from "astro:assets";
+
 import SiteShell from "../components/layout/SiteShell.astro";
 import SiteHead from "../components/seo/SiteHead.astro";
+import { getSiteSocialFallbackImage } from "../lib/content";
+import {
+  normalizeRouteMetadata,
+  type RobotsPolicy,
+  type RouteMetadataKind,
+  type JsonLdNode,
+} from "../lib/metadata";
 import { SITE_DESCRIPTION, SITE_TITLE } from "../lib/routes";
 import { siteConfig } from "../lib/site-config";
-import type { SocialPreviewImage } from "../lib/social-images";
+import {
+  type SocialPreviewImage,
+  socialPreviewImageViewModel,
+} from "../lib/social-images";
 
 interface Props {
   title?: string;
   description?: string;
   canonicalPath?: string;
   image?: SocialPreviewImage | undefined;
+  kind?: RouteMetadataKind;
+  robots?: RobotsPolicy | undefined;
+  structuredData?: readonly (JsonLdNode | undefined)[] | undefined;
   type?: "website" | "article";
 }
 
@@ -22,8 +37,27 @@ const {
   description = SITE_DESCRIPTION,
   canonicalPath = Astro.url.pathname,
   image,
+  kind = "page",
+  robots,
+  structuredData = [],
   type = "website",
 } = Astro.props;
+const metadata = normalizeRouteMetadata({
+  canonicalPath,
+  description,
+  kind,
+  robots,
+  title,
+});
+const socialPreviewImage =
+  image ??
+  (metadata.robots === "index,follow"
+    ? await socialPreviewImageViewModel({
+        alt: siteConfig.identity.title,
+        fallback: await getSiteSocialFallbackImage(),
+        optimize: getImage,
+      })
+    : undefined);
 ---
 
 <!doctype html>
@@ -35,10 +69,9 @@ const {
     <link rel="icon" href="/favicon.svg?v=2" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <SiteHead
-      canonicalPath={canonicalPath}
-      description={description}
-      image={image}
-      title={title}
+      image={socialPreviewImage}
+      metadata={metadata}
+      structuredData={structuredData}
       type={type}
     />
     <slot name="head" />

--- a/src/lib/article-page-view-model.ts
+++ b/src/lib/article-page-view-model.ts
@@ -15,6 +15,7 @@ import {
   type ArticleScholarMetaViewModel,
   articleScholarMetaViewModel,
 } from "./article-pdf";
+import type { ArticleReferenceData } from "./article-references/model";
 import {
   type ArticleTableOfContentsHeading,
   hasUsefulTableOfContents,
@@ -87,6 +88,7 @@ export interface ArticlePageViewModel {
 
 interface ArticlePageViewModelInput {
   article: ArticleEntry;
+  articleReferences?: ArticleReferenceData | undefined;
   config?: SiteConfig | undefined;
   content?: Partial<ArticlePageContentInput> | undefined;
   optimizeImage: SocialPreviewImageOptimizer;
@@ -107,6 +109,7 @@ interface ArticlePageContentInput {
  *
  * @param input Article, site URL data, optimizer adapter, and optional fixtures.
  * @param input.article Article content entry.
+ * @param input.articleReferences Parsed article note and citation data.
  * @param input.config Optional site configuration override.
  * @param input.content Optional content fixture override.
  * @param input.optimizeImage Astro image optimizer adapter.
@@ -117,6 +120,7 @@ interface ArticlePageContentInput {
  */
 export async function articlePageViewModel({
   article,
+  articleReferences,
   config = siteConfig,
   content,
   optimizeImage,
@@ -149,6 +153,7 @@ export async function articlePageViewModel({
       : undefined;
   const scholarMeta = articleScholarMetaViewModel({
     article,
+    articleReferences,
     authors,
     config,
     site,

--- a/src/lib/article-page-view-model.ts
+++ b/src/lib/article-page-view-model.ts
@@ -42,6 +42,10 @@ import {
   type CategorySummary,
   categoryUrl,
 } from "./routes";
+import {
+  type SemanticDetailsViewModel,
+  semanticDetailsViewModel,
+} from "./semantic-metadata";
 import { absoluteUrl } from "./seo";
 import {
   type ArticleShareMenuViewModel,
@@ -79,6 +83,7 @@ export interface ArticlePageViewModel {
   readingNavigationLinks: Array<{ href: string; label: string }>;
   scholarMeta: ArticleScholarMetaViewModel;
   searchable: boolean;
+  semanticDetails?: SemanticDetailsViewModel | undefined;
   share: ArticleShareMenuViewModel;
   showTableOfContents: boolean;
   socialPreviewImage: SocialPreviewImage;
@@ -207,6 +212,7 @@ export async function articlePageViewModel({
         article.data.visibility,
         config.contentDefaults.articles.visibility,
       ).search,
+    semanticDetails: semanticDetailsViewModel(article.data.semantic),
     share: articleShareMenuViewModel({
       articleUrl: canonicalUrl,
       description: articleView.description,

--- a/src/lib/article-pdf.ts
+++ b/src/lib/article-pdf.ts
@@ -1,3 +1,4 @@
+import type { ArticleReferenceData } from "./article-references/model";
 import type { AuthorSummary } from "./authors";
 import {
   type ArticleEntry,
@@ -12,10 +13,14 @@ import { type SiteConfig, siteConfig } from "./site-config";
 
 /** Display-ready Scholar metadata for one article page. */
 export interface ArticleScholarMetaViewModel {
+  abstract: string;
   authors: readonly string[];
+  keywords: readonly string[];
+  language: string;
   pdf?: ArticlePdfViewModel | undefined;
   publicationDate: Date;
   publicationDateForScholar: string;
+  references: readonly string[];
   title: string;
 }
 
@@ -33,8 +38,11 @@ export interface ArticlePdfViewModel {
 
 interface ArticlePdfViewModelInput {
   article: ArticleEntry;
+  articleReferences?: ArticleReferenceData | undefined;
   authors?: readonly AuthorSummary[];
-  config?: Pick<SiteConfig, "contentDefaults" | "features"> | undefined;
+  config?:
+    | Pick<SiteConfig, "contentDefaults" | "features" | "identity">
+    | undefined;
   site?: string | undefined | URL;
 }
 
@@ -43,6 +51,7 @@ interface ArticlePdfViewModelInput {
  *
  * @param input Article entry, resolved authors, and optional site origin.
  * @param input.article Article content entry.
+ * @param input.articleReferences Parsed article note and citation data.
  * @param input.authors Resolved structured author summaries.
  * @param input.config Optional site config override for feature/default policy.
  * @param input.site Optional site origin for absolute Scholar URLs.
@@ -50,6 +59,7 @@ interface ArticlePdfViewModelInput {
  */
 export function articleScholarMetaViewModel({
   article,
+  articleReferences,
   authors = [],
   config = siteConfig,
   site,
@@ -61,7 +71,10 @@ export function articleScholarMetaViewModel({
   const title = entryTitle(article);
 
   return {
+    abstract: article.data.description,
     authors: authorNames,
+    keywords: article.data.tags,
+    language: config.identity.language,
     pdf: articlePdfEnabled(article, config)
       ? {
           articleUrl: absoluteUrl(articleUrl(slug), site),
@@ -76,6 +89,7 @@ export function articleScholarMetaViewModel({
       : undefined,
     publicationDate,
     publicationDateForScholar,
+    references: scholarCitationReferences(articleReferences),
     title,
   };
 }
@@ -159,4 +173,25 @@ function articlePdfAuthorNames(
   }
 
   return [authorName(article)];
+}
+
+function scholarCitationReferences(
+  articleReferences: ArticleReferenceData | undefined,
+): string[] {
+  if (articleReferences === undefined) {
+    return [];
+  }
+
+  return articleReferences.citations
+    .map((citation) =>
+      citation.definition.children
+        .map((block) => block.text)
+        .join(" ")
+        .replace(/\s+/gu, " ")
+        .trim(),
+    )
+    .filter((reference) => reference.length > 0)
+    .filter(
+      (reference, index, references) => references.indexOf(reference) === index,
+    );
 }

--- a/src/lib/content-schemas.ts
+++ b/src/lib/content-schemas.ts
@@ -146,6 +146,7 @@ function createArticleSchema(
     legacyPermalink: z.string().optional(),
     tags: tagListSchema(),
     title: z.string().min(1),
+    updated: z.coerce.date().optional(),
     visibility: publishableVisibilitySchema(defaults.visibility),
   };
 

--- a/src/lib/content-schemas.ts
+++ b/src/lib/content-schemas.ts
@@ -1,6 +1,7 @@
 import type { ImageMetadata } from "astro";
 import { z } from "astro/zod";
 
+import { semanticMetadataSchema } from "./semantic-metadata";
 import { tagDiagnostics } from "./tags";
 
 const publishableVisibilityDefaults = {
@@ -144,6 +145,7 @@ function createArticleSchema(
     imageAlt: z.string().optional(),
     legacyBanner: z.string().optional(),
     legacyPermalink: z.string().optional(),
+    semantic: semanticMetadataSchema,
     tags: tagListSchema(),
     title: z.string().min(1),
     updated: z.coerce.date().optional(),

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,0 +1,514 @@
+import { absoluteUrl } from "./seo";
+import { type SiteConfig, siteConfig } from "./site-config";
+
+/** Supported route-family names for normalized metadata. */
+export type RouteMetadataKind =
+  | "announcement"
+  | "announcements-index"
+  | "article"
+  | "articles-archive"
+  | "articles-index"
+  | "author-index"
+  | "author-profile"
+  | "bibliography"
+  | "catalog"
+  | "category-detail"
+  | "category-index"
+  | "collection-detail"
+  | "collection-index"
+  | "home"
+  | "not-found"
+  | "page"
+  | "redirect"
+  | "search"
+  | "tag-detail"
+  | "tag-index";
+
+/** Robots policies emitted by the platform. */
+export type RobotsPolicy = "index,follow" | "noindex,follow";
+
+/** Machine-readable discovery policy for a route or publishable entry. */
+export interface DiscoveryPolicy {
+  contentIndex: boolean;
+  feed: boolean;
+  sitemap: boolean;
+}
+
+/** Visibility fields available on article-like content. */
+export interface PublishableVisibility {
+  directory: boolean;
+  feed: boolean;
+  search: boolean;
+}
+
+/** Minimal visible item shape accepted by `ItemList` metadata helpers. */
+export interface MetadataListItem {
+  description?: string | undefined;
+  href: string;
+  title: string;
+}
+
+/** Minimal breadcrumb item shape accepted by metadata helpers. */
+export interface MetadataBreadcrumbItem {
+  href: string;
+  title: string;
+}
+
+/** Inputs supplied by routes before metadata normalization. */
+export interface RouteMetadataInput {
+  canonicalPath: string;
+  description: string;
+  kind: RouteMetadataKind;
+  robots?: RobotsPolicy | undefined;
+  title: string;
+}
+
+/** Normalized route metadata consumed by layouts and validation code. */
+export interface RouteMetadata extends RouteMetadataInput {
+  discovery: DiscoveryPolicy;
+  robots: RobotsPolicy;
+}
+
+/** Schema.org JSON-LD node used by metadata builders. */
+export type JsonLdNode = Record<string, unknown>;
+
+const noindexRouteKinds = new Set<RouteMetadataKind>([
+  "catalog",
+  "not-found",
+  "redirect",
+  "search",
+]);
+
+/**
+ * Normalizes route metadata and applies platform-level robots/discovery rules.
+ *
+ * @param input Route-specific metadata facts.
+ * @returns Metadata with explicit robots and discovery policy.
+ */
+export function normalizeRouteMetadata(
+  input: RouteMetadataInput,
+): RouteMetadata {
+  const robots = input.robots ?? routeRobotsPolicy(input.kind);
+
+  return {
+    ...input,
+    discovery: routeDiscoveryPolicy(input.kind, robots),
+    robots,
+  };
+}
+
+/**
+ * Resolves the default robots policy for a route family.
+ *
+ * @param kind Route metadata kind.
+ * @returns Indexable route policy unless the route is utility/private output.
+ */
+export function routeRobotsPolicy(kind: RouteMetadataKind): RobotsPolicy {
+  return noindexRouteKinds.has(kind) ? "noindex,follow" : "index,follow";
+}
+
+/**
+ * Resolves sitemap/feed/search-index policy for a route family.
+ *
+ * @param kind Route metadata kind.
+ * @param robots Effective robots policy for the route.
+ * @returns Machine-readable discovery policy.
+ */
+export function routeDiscoveryPolicy(
+  kind: RouteMetadataKind,
+  robots: RobotsPolicy = routeRobotsPolicy(kind),
+): DiscoveryPolicy {
+  if (robots === "noindex,follow") {
+    return { contentIndex: false, feed: false, sitemap: false };
+  }
+
+  return {
+    contentIndex: routeContentIndexPolicy(kind),
+    feed: false,
+    sitemap: routeSitemapPolicy(kind),
+  };
+}
+
+/**
+ * Maps article-like content visibility to public discovery surfaces.
+ *
+ * @param visibility Normalized frontmatter/config visibility.
+ * @returns Discovery policy for the concrete published entry.
+ */
+export function publishableDiscoveryPolicy(
+  visibility: PublishableVisibility,
+): DiscoveryPolicy {
+  return {
+    contentIndex: visibility.search,
+    feed: visibility.feed,
+    sitemap: visibility.directory,
+  };
+}
+
+/**
+ * Determines whether a path should be included in the generated sitemap.
+ *
+ * @param pathname Absolute URL path from the sitemap integration.
+ * @param config Site configuration with configured feature route roots.
+ * @returns False for known noindex utility routes.
+ */
+export function sitemapIncludesPath(
+  pathname: string,
+  config: SiteConfig = siteConfig,
+): boolean {
+  const normalizedPathname = ensureLeadingAndTrailingSlash(pathname);
+  const excludedRoutes = [config.routes.search, "/404/", "/catalog/"].map(
+    ensureLeadingAndTrailingSlash,
+  );
+
+  return !excludedRoutes.some((route) => normalizedPathname.startsWith(route));
+}
+
+/**
+ * Builds the stable site root URL used in JSON-LD `@id` values.
+ *
+ * @param site Astro site URL when available.
+ * @returns Absolute site root URL with a trailing slash and no hash.
+ */
+export function siteRootUrl(site: string | undefined | URL): string {
+  return absoluteUrl("/", site).replace(/\/+$/u, "/");
+}
+
+/**
+ * Builds the stable `WebSite` JSON-LD ID.
+ *
+ * @param site Astro site URL when available.
+ * @returns Stable `WebSite` ID.
+ */
+export function websiteEntityId(site: string | undefined | URL): string {
+  return `${siteRootUrl(site)}#website`;
+}
+
+/**
+ * Builds the stable publisher `Organization`/`Person` JSON-LD ID.
+ *
+ * @param site Astro site URL when available.
+ * @returns Stable publisher ID.
+ */
+export function publisherEntityId(site: string | undefined | URL): string {
+  return `${siteRootUrl(site)}#publisher`;
+}
+
+/**
+ * Builds a stable route-scoped JSON-LD ID.
+ *
+ * @param canonicalPath Route canonical path or URL.
+ * @param fragment Fragment without a leading `#`.
+ * @param site Astro site URL when available.
+ * @returns Absolute route URL with a hash ID.
+ */
+export function routeEntityId(
+  canonicalPath: string,
+  fragment: string,
+  site: string | undefined | URL,
+): string {
+  return `${absoluteUrl(canonicalPath, site).split("#")[0] ?? ""}#${fragment}`;
+}
+
+/**
+ * Builds the stable `WebPage` JSON-LD ID for a route.
+ *
+ * @param canonicalPath Route canonical path or URL.
+ * @param site Astro site URL when available.
+ * @returns Stable route `WebPage` ID.
+ */
+export function webPageEntityId(
+  canonicalPath: string,
+  site: string | undefined | URL,
+): string {
+  return routeEntityId(canonicalPath, "webpage", site);
+}
+
+/**
+ * Builds the stable `ItemList` JSON-LD ID for a route.
+ *
+ * @param canonicalPath Route canonical path or URL.
+ * @param site Astro site URL when available.
+ * @returns Stable route `ItemList` ID.
+ */
+export function itemListEntityId(
+  canonicalPath: string,
+  site: string | undefined | URL,
+): string {
+  return routeEntityId(canonicalPath, "itemlist", site);
+}
+
+/**
+ * Builds the stable `BreadcrumbList` JSON-LD ID for a route.
+ *
+ * @param canonicalPath Route canonical path or URL.
+ * @param site Astro site URL when available.
+ * @returns Stable route `BreadcrumbList` ID.
+ */
+export function breadcrumbEntityId(
+  canonicalPath: string,
+  site: string | undefined | URL,
+): string {
+  return routeEntityId(canonicalPath, "breadcrumb", site);
+}
+
+/**
+ * Builds stable publisher and website nodes for every indexable site route.
+ *
+ * @param site Astro site URL when available.
+ * @param config Site identity configuration.
+ * @returns Publisher and `WebSite` JSON-LD nodes.
+ */
+export function siteIdentityJsonLd(
+  site: string | undefined | URL,
+  config: SiteConfig = siteConfig,
+): JsonLdNode[] {
+  const publisherId = publisherEntityId(site);
+  const publisherType =
+    config.identity.publisherType === "person" ? "Person" : "Organization";
+  const publisher = compactJsonLdNode({
+    "@id": publisherId,
+    "@type": publisherType,
+    logo:
+      config.identity.logo === undefined
+        ? undefined
+        : {
+            "@type": "ImageObject",
+            url: absoluteUrl(config.identity.logo, site),
+          },
+    name: config.identity.publisherName ?? config.identity.title,
+    sameAs:
+      config.identity.sameAs.length === 0 ? undefined : config.identity.sameAs,
+    url: siteRootUrl(site),
+  });
+  const website = compactJsonLdNode({
+    "@id": websiteEntityId(site),
+    "@type": "WebSite",
+    alternateName: config.identity.shortTitle,
+    description: config.identity.description,
+    inLanguage: config.identity.language,
+    name: config.identity.title,
+    publisher: { "@id": publisherId },
+    url: siteRootUrl(site),
+  });
+
+  return [publisher, website];
+}
+
+/**
+ * Builds a route-level `WebPage` JSON-LD node from normalized metadata.
+ *
+ * @param metadata Normalized route metadata.
+ * @param site Astro site URL when available.
+ * @param config Site identity configuration.
+ * @returns Conservative `WebPage` JSON-LD node.
+ */
+export function webPageJsonLd(
+  metadata: RouteMetadata,
+  site: string | undefined | URL,
+  config: SiteConfig = siteConfig,
+): JsonLdNode {
+  return compactJsonLdNode({
+    "@id": webPageEntityId(metadata.canonicalPath, site),
+    "@type": webPageSchemaType(metadata.kind),
+    description: metadata.description,
+    inLanguage: config.identity.language,
+    isPartOf: { "@id": websiteEntityId(site) },
+    name: metadata.title,
+    publisher: { "@id": publisherEntityId(site) },
+    url: absoluteUrl(metadata.canonicalPath, site),
+  });
+}
+
+/**
+ * Serializes route metadata nodes as one Schema.org graph.
+ *
+ * @param nodes JSON-LD nodes to include.
+ * @returns JSON-LD graph object or undefined when there are no nodes.
+ */
+export function jsonLdGraph(
+  nodes: readonly JsonLdNode[],
+): JsonLdNode | undefined {
+  const graph = nodes.filter((node) => Object.keys(node).length > 0);
+
+  return graph.length === 0
+    ? undefined
+    : {
+        "@context": "https://schema.org",
+        "@graph": graph,
+      };
+}
+
+/**
+ * Builds a Schema.org `ItemList` for items visibly represented on a route.
+ *
+ * @param canonicalPath Route canonical path owning the list.
+ * @param items Visible items in display order.
+ * @param site Astro site URL when available.
+ * @returns ItemList node, or undefined when there are no visible items.
+ */
+export function itemListJsonLd(
+  canonicalPath: string,
+  items: readonly MetadataListItem[],
+  site: string | undefined | URL,
+): JsonLdNode | undefined {
+  if (items.length === 0) {
+    return undefined;
+  }
+
+  return {
+    "@id": itemListEntityId(canonicalPath, site),
+    "@type": "ItemList",
+    itemListElement: items.map((item, index) =>
+      compactJsonLdNode({
+        "@type": "ListItem",
+        description: item.description,
+        name: item.title,
+        position: index + 1,
+        url: absoluteUrl(item.href, site),
+      }),
+    ),
+    numberOfItems: items.length,
+  };
+}
+
+/**
+ * Builds a Schema.org `BreadcrumbList` for real site hierarchy.
+ *
+ * @param canonicalPath Route canonical path owning the breadcrumb list.
+ * @param items Breadcrumbs in top-to-current order.
+ * @param site Astro site URL when available.
+ * @returns BreadcrumbList node, or undefined when there is no hierarchy.
+ */
+export function breadcrumbListJsonLd(
+  canonicalPath: string,
+  items: readonly MetadataBreadcrumbItem[],
+  site: string | undefined | URL,
+): JsonLdNode | undefined {
+  if (items.length < 2) {
+    return undefined;
+  }
+
+  return {
+    "@id": breadcrumbEntityId(canonicalPath, site),
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      item: absoluteUrl(item.href, site),
+      name: item.title,
+      position: index + 1,
+    })),
+  };
+}
+
+/**
+ * Builds a conservative author profile entity node.
+ *
+ * @param input Author profile facts visible on the author page.
+ * @param input.href Canonical author URL.
+ * @param input.name Display name.
+ * @param input.type Author profile kind.
+ * @param input.description Optional visible short biography.
+ * @param input.sameAs Optional external profile links.
+ * @param site Astro site URL when available.
+ * @returns Person or Organization node for a profile route.
+ */
+export function profileEntityJsonLd(
+  input: {
+    description?: string | undefined;
+    href: string;
+    name: string;
+    sameAs?: readonly string[] | undefined;
+    type: "anonymous" | "collective" | "organization" | "person";
+  },
+  site: string | undefined | URL,
+): JsonLdNode {
+  return compactJsonLdNode({
+    "@id": routeEntityId(input.href, "author", site),
+    "@type":
+      input.type === "organization" || input.type === "collective"
+        ? "Organization"
+        : "Person",
+    description: input.description,
+    name: input.name,
+    sameAs:
+      input.sameAs === undefined || input.sameAs.length === 0
+        ? undefined
+        : input.sameAs,
+    url: absoluteUrl(input.href, site),
+  });
+}
+
+function routeSitemapPolicy(kind: RouteMetadataKind): boolean {
+  return kind !== "redirect";
+}
+
+function routeContentIndexPolicy(kind: RouteMetadataKind): boolean {
+  return !(
+    kind === "articles-archive" ||
+    kind === "bibliography" ||
+    kind === "redirect"
+  );
+}
+
+function webPageSchemaType(kind: RouteMetadataKind): string {
+  switch (kind) {
+    case "announcement":
+      return "WebPage";
+    case "announcements-index":
+      return "CollectionPage";
+    case "article":
+      return "WebPage";
+    case "articles-archive":
+      return "CollectionPage";
+    case "articles-index":
+      return "CollectionPage";
+    case "author-index":
+      return "WebPage";
+    case "author-profile":
+      return "ProfilePage";
+    case "bibliography":
+      return "CollectionPage";
+    case "catalog":
+      return "WebPage";
+    case "category-detail":
+      return "CollectionPage";
+    case "category-index":
+      return "CollectionPage";
+    case "collection-detail":
+      return "CollectionPage";
+    case "collection-index":
+      return "CollectionPage";
+    case "home":
+      return "WebPage";
+    case "not-found":
+      return "WebPage";
+    case "page":
+      return "WebPage";
+    case "redirect":
+      return "WebPage";
+    case "search":
+      return "WebPage";
+    case "tag-detail":
+      return "CollectionPage";
+    case "tag-index":
+      return "CollectionPage";
+  }
+}
+
+function compactJsonLdNode(node: JsonLdNode): JsonLdNode {
+  return Object.fromEntries(
+    Object.entries(node).filter(([, value]) => value !== undefined),
+  );
+}
+
+function ensureLeadingAndTrailingSlash(pathname: string): string {
+  const cleanPathname = pathname.split("?")[0]?.split("#")[0] ?? "/";
+  const withLeadingSlash = cleanPathname.startsWith("/")
+    ? cleanPathname
+    : `/${cleanPathname}`;
+
+  return withLeadingSlash.endsWith("/")
+    ? withLeadingSlash
+    : `${withLeadingSlash}/`;
+}

--- a/src/lib/semantic-metadata.ts
+++ b/src/lib/semantic-metadata.ts
@@ -1,0 +1,677 @@
+import { z } from "astro/zod";
+
+import { type JsonLdNode, routeEntityId } from "./metadata";
+import { formatDate } from "./routes";
+
+const semanticItemTypeSchema = z.enum([
+  "article",
+  "audio",
+  "book",
+  "creative-work",
+  "dataset",
+  "event",
+  "software",
+  "video",
+]);
+
+const nonEmptyString = z.string().trim().min(1);
+const optionalUrl = z.string().url().optional();
+const optionalDate = z.coerce.date().optional();
+const peopleSchema = z.union([nonEmptyString, z.array(nonEmptyString).min(1)]);
+
+const semanticItemSchema = z
+  .object({
+    author: peopleSchema.optional(),
+    datePublished: optionalDate,
+    description: nonEmptyString.optional(),
+    name: nonEmptyString,
+    type: semanticItemTypeSchema,
+    url: optionalUrl,
+  })
+  .strict();
+
+const ratingSchema = z
+  .object({
+    best: z.number().positive().optional(),
+    value: z.number(),
+    worst: z.number().optional(),
+  })
+  .strict()
+  .superRefine((rating, context) => {
+    if (
+      rating.best !== undefined &&
+      rating.worst !== undefined &&
+      rating.best <= rating.worst
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "rating.best must be greater than rating.worst.",
+        path: ["best"],
+      });
+    }
+  });
+
+const reviewSchema = z
+  .object({
+    item: semanticItemSchema,
+    kind: z.literal("review"),
+    rating: ratingSchema.optional(),
+    summary: nonEmptyString.optional(),
+  })
+  .strict();
+
+const eventLocationSchema = z.discriminatedUnion("type", [
+  z
+    .object({
+      type: z.literal("online"),
+      url: z.string().url(),
+    })
+    .strict(),
+  z
+    .object({
+      address: nonEmptyString.optional(),
+      name: nonEmptyString,
+      type: z.literal("place"),
+      url: optionalUrl,
+    })
+    .strict(),
+]);
+
+const eventSchema = z
+  .object({
+    attendance: z.enum(["mixed", "offline", "online"]).optional(),
+    description: nonEmptyString.optional(),
+    endDate: optionalDate,
+    kind: z.literal("event"),
+    location: eventLocationSchema.optional(),
+    name: nonEmptyString,
+    startDate: z.coerce.date(),
+    status: z
+      .enum([
+        "cancelled",
+        "moved-online",
+        "postponed",
+        "rescheduled",
+        "scheduled",
+      ])
+      .default("scheduled"),
+    url: optionalUrl,
+  })
+  .strict()
+  .superRefine((event, context) => {
+    if (event.endDate !== undefined && event.endDate < event.startDate) {
+      context.addIssue({
+        code: "custom",
+        message: "event.endDate must be after event.startDate.",
+        path: ["endDate"],
+      });
+    }
+  });
+
+const mediaSchema = z
+  .object({
+    description: nonEmptyString.optional(),
+    duration: nonEmptyString.optional(),
+    embedUrl: optionalUrl,
+    kind: z.enum(["audio", "video"]),
+    name: nonEmptyString,
+    thumbnailUrl: optionalUrl,
+    uploadDate: optionalDate,
+    url: optionalUrl,
+  })
+  .strict();
+
+const bookSchema = z
+  .object({
+    author: peopleSchema.optional(),
+    datePublished: optionalDate,
+    description: nonEmptyString.optional(),
+    isbn: nonEmptyString.optional(),
+    kind: z.literal("book"),
+    name: nonEmptyString,
+    publisher: nonEmptyString.optional(),
+    url: optionalUrl,
+  })
+  .strict();
+
+const distributionSchema = z
+  .object({
+    encodingFormat: nonEmptyString.optional(),
+    url: z.string().url(),
+  })
+  .strict();
+
+const datasetSchema = z
+  .object({
+    creator: peopleSchema.optional(),
+    description: nonEmptyString,
+    distribution: z.array(distributionSchema).default([]),
+    kind: z.literal("dataset"),
+    license: optionalUrl,
+    name: nonEmptyString,
+    url: optionalUrl,
+  })
+  .strict();
+
+const softwareSchema = z
+  .object({
+    applicationCategory: nonEmptyString.optional(),
+    description: nonEmptyString.optional(),
+    kind: z.literal("software"),
+    license: optionalUrl,
+    name: nonEmptyString,
+    operatingSystem: nonEmptyString.optional(),
+    url: optionalUrl,
+    version: nonEmptyString.optional(),
+  })
+  .strict();
+
+const faqSchema = z
+  .object({
+    items: z
+      .array(
+        z
+          .object({
+            answer: nonEmptyString,
+            question: nonEmptyString,
+          })
+          .strict(),
+      )
+      .min(1),
+    kind: z.literal("faq"),
+  })
+  .strict();
+
+export const semanticMetadataSchema = z
+  .discriminatedUnion("kind", [
+    reviewSchema,
+    eventSchema,
+    mediaSchema,
+    bookSchema,
+    datasetSchema,
+    softwareSchema,
+    faqSchema,
+  ])
+  .optional();
+
+/** Optional author-facing semantic profile parsed from article-like frontmatter. */
+export type SemanticMetadata = z.infer<typeof semanticMetadataSchema>;
+
+/** Present semantic profile after callers have handled the omitted case. */
+type SemanticMetadataProfile = Exclude<SemanticMetadata, undefined>;
+
+/** Visible semantic facts rendered on article-like pages. */
+export interface SemanticDetailsViewModel {
+  description?: string | undefined;
+  heading: string;
+  items: readonly SemanticDetailsItem[];
+}
+
+/** One visible semantic fact for a page profile. */
+interface SemanticDetailsItem {
+  href?: string | undefined;
+  label: string;
+  value: string;
+}
+
+/** Optional semantic JSON-LD nodes plus references from the base article node. */
+export interface SemanticJsonLdResult {
+  nodes: readonly JsonLdNode[];
+  references: ReadonlyArray<Record<"@id", string>>;
+}
+
+interface SemanticJsonLdInput {
+  authorName: string;
+  canonicalPath: string;
+  datePublished: Date;
+  site: string | undefined | URL;
+}
+
+/**
+ * Builds visible semantic detail facts from validated frontmatter.
+ *
+ * @param semantic Optional semantic profile from article-like frontmatter.
+ * @returns Compact details view model, or undefined when no profile exists.
+ */
+export function semanticDetailsViewModel(
+  semantic: SemanticMetadata,
+): SemanticDetailsViewModel | undefined {
+  if (semantic === undefined) {
+    return undefined;
+  }
+
+  switch (semantic.kind) {
+    case "audio":
+      return mediaDetails("Audio details", semantic);
+    case "book":
+      return compactDetails("Book details", semantic.description, [
+        fact("Title", semantic.name, semantic.url),
+        peopleFact("Author", semantic.author),
+        fact("Publisher", semantic.publisher),
+        fact("Published", formatDate(semantic.datePublished)),
+        fact("ISBN", semantic.isbn),
+      ]);
+    case "dataset":
+      return compactDetails("Dataset details", semantic.description, [
+        fact("Dataset", semantic.name, semantic.url),
+        peopleFact("Creator", semantic.creator),
+        fact("License", semantic.license, semantic.license),
+        fact(
+          "Downloads",
+          semantic.distribution
+            .map(
+              (distribution) => distribution.encodingFormat ?? distribution.url,
+            )
+            .join(", "),
+        ),
+      ]);
+    case "event":
+      return compactDetails("Event details", semantic.description, [
+        fact("Event", semantic.name, semantic.url),
+        fact("Starts", formatDate(semantic.startDate)),
+        fact("Ends", formatDate(semantic.endDate)),
+        fact(
+          "Location",
+          eventLocationLabel(semantic.location),
+          eventLocationUrl(semantic.location),
+        ),
+        fact("Attendance", semantic.attendance),
+        fact("Status", semantic.status),
+      ]);
+    case "faq":
+      return {
+        heading: "FAQ",
+        items: semantic.items.map((item) => ({
+          label: item.question,
+          value: item.answer,
+        })),
+      };
+    case "review":
+      return compactDetails("Review details", semantic.summary, [
+        fact("Reviewed", semantic.item.name, semantic.item.url),
+        fact("Type", itemTypeLabel(semantic.item.type)),
+        peopleFact("Author", semantic.item.author),
+        fact("Published", formatDate(semantic.item.datePublished)),
+        fact("Rating", ratingLabel(semantic.rating)),
+      ]);
+    case "software":
+      return compactDetails("Software details", semantic.description, [
+        fact("Software", semantic.name, semantic.url),
+        fact("Version", semantic.version),
+        fact("Category", semantic.applicationCategory),
+        fact("Operating system", semantic.operatingSystem),
+        fact("License", semantic.license, semantic.license),
+      ]);
+    case "video":
+      return mediaDetails("Video details", semantic);
+  }
+}
+
+/**
+ * Builds optional semantic JSON-LD nodes from validated article-like metadata.
+ *
+ * @param semantic Optional semantic profile from frontmatter.
+ * @param input Route and article facts used for stable IDs and authorship.
+ * @returns JSON-LD nodes plus `@id` references for the base article node.
+ */
+export function semanticMetadataJsonLd(
+  semantic: SemanticMetadata,
+  input: SemanticJsonLdInput,
+): SemanticJsonLdResult {
+  if (semantic === undefined) {
+    return { nodes: [], references: [] };
+  }
+
+  const id = semanticEntityId(input.canonicalPath, semantic.kind, input.site);
+  const node = semanticNodeJsonLd(id, semantic, input);
+
+  return {
+    nodes: [node],
+    references: [{ "@id": id }],
+  };
+}
+
+function semanticNodeJsonLd(
+  id: string,
+  semantic: SemanticMetadataProfile,
+  input: SemanticJsonLdInput,
+): JsonLdNode {
+  switch (semantic.kind) {
+    case "audio":
+      return mediaJsonLd(id, "AudioObject", semantic);
+    case "book":
+      return compactJsonLdNode({
+        "@id": id,
+        "@type": "Book",
+        author: peopleJsonLd(semantic.author),
+        datePublished: semantic.datePublished?.toISOString(),
+        description: semantic.description,
+        isbn: semantic.isbn,
+        name: semantic.name,
+        publisher: semantic.publisher,
+        url: semantic.url,
+      });
+    case "dataset":
+      return compactJsonLdNode({
+        "@id": id,
+        "@type": "Dataset",
+        creator: peopleJsonLd(semantic.creator),
+        description: semantic.description,
+        distribution:
+          semantic.distribution.length === 0
+            ? undefined
+            : semantic.distribution.map((distribution) =>
+                compactJsonLdNode({
+                  "@type": "DataDownload",
+                  contentUrl: distribution.url,
+                  encodingFormat: distribution.encodingFormat,
+                }),
+              ),
+        license: semantic.license,
+        name: semantic.name,
+        url: semantic.url,
+      });
+    case "event":
+      return compactJsonLdNode({
+        "@id": id,
+        "@type": "Event",
+        attendanceMode: attendanceModeJsonLd(semantic.attendance),
+        description: semantic.description,
+        endDate: semantic.endDate?.toISOString(),
+        eventStatus: eventStatusJsonLd(semantic.status),
+        location: eventLocationJsonLd(semantic.location),
+        name: semantic.name,
+        startDate: semantic.startDate.toISOString(),
+        url: semantic.url,
+      });
+    case "faq":
+      return {
+        "@id": id,
+        "@type": "FAQPage",
+        mainEntity: semantic.items.map((item) => ({
+          "@type": "Question",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: item.answer,
+          },
+          name: item.question,
+        })),
+      };
+    case "review":
+      return compactJsonLdNode({
+        "@id": id,
+        "@type": "Review",
+        author: {
+          "@type": "Person",
+          name: input.authorName,
+        },
+        datePublished: input.datePublished.toISOString(),
+        itemReviewed: semanticItemJsonLd(semantic.item),
+        reviewBody: semantic.summary,
+        reviewRating: ratingJsonLd(semantic.rating),
+      });
+    case "software":
+      return compactJsonLdNode({
+        "@id": id,
+        "@type": "SoftwareApplication",
+        applicationCategory: semantic.applicationCategory,
+        description: semantic.description,
+        license: semantic.license,
+        name: semantic.name,
+        operatingSystem: semantic.operatingSystem,
+        softwareVersion: semantic.version,
+        url: semantic.url,
+      });
+    case "video":
+      return mediaJsonLd(id, "VideoObject", semantic);
+  }
+}
+
+function mediaDetails(
+  heading: string,
+  semantic: Extract<SemanticMetadataProfile, { kind: "audio" | "video" }>,
+): SemanticDetailsViewModel {
+  return compactDetails(heading, semantic.description, [
+    fact("Title", semantic.name, semantic.url),
+    fact("Published", formatDate(semantic.uploadDate)),
+    fact("Duration", semantic.duration),
+    fact("Embed", semantic.embedUrl, semantic.embedUrl),
+  ]);
+}
+
+function mediaJsonLd(
+  id: string,
+  type: "AudioObject" | "VideoObject",
+  semantic: Extract<SemanticMetadataProfile, { kind: "audio" | "video" }>,
+): JsonLdNode {
+  return compactJsonLdNode({
+    "@id": id,
+    "@type": type,
+    description: semantic.description,
+    duration: semantic.duration,
+    embedUrl: semantic.embedUrl,
+    name: semantic.name,
+    thumbnailUrl: semantic.thumbnailUrl,
+    uploadDate: semantic.uploadDate?.toISOString(),
+    url: semantic.url,
+  });
+}
+
+function semanticItemJsonLd(
+  item: z.infer<typeof semanticItemSchema>,
+): JsonLdNode {
+  return compactJsonLdNode({
+    "@type": schemaTypeForItem(item.type),
+    author: peopleJsonLd(item.author),
+    datePublished: item.datePublished?.toISOString(),
+    description: item.description,
+    name: item.name,
+    url: item.url,
+  });
+}
+
+function ratingJsonLd(
+  rating: undefined | z.infer<typeof ratingSchema>,
+): JsonLdNode | undefined {
+  return rating === undefined
+    ? undefined
+    : compactJsonLdNode({
+        "@type": "Rating",
+        bestRating: rating.best,
+        ratingValue: rating.value,
+        worstRating: rating.worst,
+      });
+}
+
+function peopleJsonLd(
+  people: undefined | z.infer<typeof peopleSchema>,
+): JsonLdNode | readonly JsonLdNode[] | undefined {
+  if (people === undefined) {
+    return undefined;
+  }
+
+  const names = Array.isArray(people) ? people : [people];
+  const peopleNodes = names.map((name) => ({
+    "@type": "Person",
+    name,
+  }));
+
+  return peopleNodes.length === 1 ? peopleNodes[0] : peopleNodes;
+}
+
+function compactDetails(
+  heading: string,
+  description: string | undefined,
+  items: ReadonlyArray<SemanticDetailsItem | undefined>,
+): SemanticDetailsViewModel {
+  return {
+    description,
+    heading,
+    items: items.filter(
+      (item): item is SemanticDetailsItem => item !== undefined,
+    ),
+  };
+}
+
+function fact(
+  label: string,
+  value: string | undefined,
+  href?: string,
+): SemanticDetailsItem | undefined {
+  return value === undefined || value.length === 0
+    ? undefined
+    : { href, label, value };
+}
+
+function peopleFact(
+  label: string,
+  people: undefined | z.infer<typeof peopleSchema>,
+): SemanticDetailsItem | undefined {
+  if (people === undefined) {
+    return undefined;
+  }
+
+  return fact(label, Array.isArray(people) ? people.join(", ") : people);
+}
+
+function ratingLabel(
+  rating: undefined | z.infer<typeof ratingSchema>,
+): string | undefined {
+  if (rating === undefined) {
+    return undefined;
+  }
+
+  return rating.best === undefined
+    ? rating.value.toString()
+    : `${rating.value}/${rating.best}`;
+}
+
+function semanticEntityId(
+  canonicalPath: string,
+  kind: SemanticMetadataProfile["kind"],
+  site: string | undefined | URL,
+): string {
+  return routeEntityId(canonicalPath, `semantic-${kind}`, site);
+}
+
+function eventLocationLabel(
+  location: undefined | z.infer<typeof eventLocationSchema>,
+): string | undefined {
+  if (location === undefined) {
+    return undefined;
+  }
+
+  return location.type === "online" ? "Online" : location.name;
+}
+
+function eventLocationUrl(
+  location: undefined | z.infer<typeof eventLocationSchema>,
+): string | undefined {
+  if (location === undefined) {
+    return undefined;
+  }
+
+  return location.url;
+}
+
+function eventLocationJsonLd(
+  location: undefined | z.infer<typeof eventLocationSchema>,
+): JsonLdNode | undefined {
+  if (location === undefined) {
+    return undefined;
+  }
+
+  return location.type === "online"
+    ? {
+        "@type": "VirtualLocation",
+        url: location.url,
+      }
+    : compactJsonLdNode({
+        "@type": "Place",
+        address: location.address,
+        name: location.name,
+        url: location.url,
+      });
+}
+
+function attendanceModeJsonLd(
+  attendance: z.infer<typeof eventSchema>["attendance"],
+): string | undefined {
+  switch (attendance) {
+    case "mixed":
+      return "https://schema.org/MixedEventAttendanceMode";
+    case "offline":
+      return "https://schema.org/OfflineEventAttendanceMode";
+    case "online":
+      return "https://schema.org/OnlineEventAttendanceMode";
+    case undefined:
+      return undefined;
+  }
+}
+
+function eventStatusJsonLd(
+  status: z.infer<typeof eventSchema>["status"],
+): string {
+  switch (status) {
+    case "cancelled":
+      return "https://schema.org/EventCancelled";
+    case "moved-online":
+      return "https://schema.org/EventMovedOnline";
+    case "postponed":
+      return "https://schema.org/EventPostponed";
+    case "rescheduled":
+      return "https://schema.org/EventRescheduled";
+    case "scheduled":
+      return "https://schema.org/EventScheduled";
+  }
+}
+
+function itemTypeLabel(type: z.infer<typeof semanticItemTypeSchema>): string {
+  switch (type) {
+    case "article":
+      return "Article";
+    case "audio":
+      return "Audio";
+    case "book":
+      return "Book";
+    case "creative-work":
+      return "Creative work";
+    case "dataset":
+      return "Dataset";
+    case "event":
+      return "Event";
+    case "software":
+      return "Software";
+    case "video":
+      return "Video";
+  }
+}
+
+function schemaTypeForItem(
+  type: z.infer<typeof semanticItemTypeSchema>,
+): string {
+  switch (type) {
+    case "article":
+      return "Article";
+    case "audio":
+      return "AudioObject";
+    case "book":
+      return "Book";
+    case "creative-work":
+      return "CreativeWork";
+    case "dataset":
+      return "Dataset";
+    case "event":
+      return "Event";
+    case "software":
+      return "SoftwareApplication";
+    case "video":
+      return "VideoObject";
+  }
+}
+
+function compactJsonLdNode(node: JsonLdNode): JsonLdNode {
+  return Object.fromEntries(
+    Object.entries(node).filter(([, value]) => value !== undefined),
+  );
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,13 +1,10 @@
 import type { AuthorSummary } from "./authors";
 import {
+  type AnnouncementEntry,
   type ArticleEntry,
   articleUrl,
   authorName,
   type CategorySummary,
-  entryDate,
-  entryTitle,
-  excerpt,
-  SITE_TITLE,
   SITE_URL,
 } from "./routes";
 import { siteConfig } from "./site-config";
@@ -16,6 +13,19 @@ import { siteConfig } from "./site-config";
 interface ArticleBlogPostingJsonLdOptions {
   image?: string | undefined;
 }
+
+interface PublishableBlogPostingJsonLdOptions {
+  authors?: readonly AuthorSummary[] | undefined;
+  canonicalPath: string;
+  fallbackAuthorName: string;
+  image?: string | undefined;
+  section?: string | undefined;
+}
+
+type PublishableBlogPostingEntry = Pick<
+  AnnouncementEntry | ArticleEntry,
+  "data" | "id"
+>;
 
 /**
  * Resolves a site-relative or absolute URL against the configured site origin.
@@ -58,33 +68,57 @@ export function articleBlogPostingJsonLd(
   authors: readonly AuthorSummary[] = [],
   options: ArticleBlogPostingJsonLdOptions = {},
 ): Record<string, unknown> {
-  const canonicalUrl = absoluteUrl(articleUrl(article.id), site);
+  return publishableBlogPostingJsonLd(article, site, {
+    authors,
+    canonicalPath: articleUrl(article.id),
+    fallbackAuthorName: authorName(article),
+    image: options.image,
+    section: category?.title ?? category?.slug,
+  });
+}
+
+/**
+ * Builds BlogPosting JSON-LD for article-like publishable entries.
+ *
+ * @param entry Article or announcement content entry.
+ * @param site Astro site origin when available.
+ * @param options Normalized route, author, image, and section metadata.
+ * @returns Schema.org BlogPosting object ready for serialization.
+ */
+export function publishableBlogPostingJsonLd(
+  entry: PublishableBlogPostingEntry,
+  site: string | undefined | URL,
+  options: PublishableBlogPostingJsonLdOptions,
+): Record<string, unknown> {
+  const canonicalUrl = absoluteUrl(options.canonicalPath, site);
   const absoluteImage =
     options.image === undefined ? undefined : absoluteUrl(options.image, site);
+  const siteRoot = absoluteUrl("/", site).replace(/\/+$/u, "/");
 
-  return {
+  return compactJsonLd({
     "@context": "https://schema.org",
     "@type": "BlogPosting",
-    articleSection: category?.title ?? category?.slug,
+    "@id": `${canonicalUrl}#article`,
+    articleSection: options.section,
     author:
-      authors.length > 0
-        ? authors.map((author) => authorJsonLd(author, site))
+      options.authors !== undefined && options.authors.length > 0
+        ? options.authors.map((author) => authorJsonLd(author, site))
         : {
             "@type": "Person",
-            name: authorName(article),
+            name: options.fallbackAuthorName,
           },
-    datePublished: entryDate(article).toISOString(),
-    description: excerpt(article),
-    headline: entryTitle(article),
+    dateModified: entry.data.updated?.toISOString(),
+    datePublished: entry.data.date.toISOString(),
+    description: entry.data.description,
+    headline: entry.data.title,
     image: absoluteImage,
-    keywords: article.data.tags,
-    mainEntityOfPage: canonicalUrl,
-    publisher: {
-      "@type": "Organization",
-      name: siteConfig.identity.publisherName ?? SITE_TITLE,
-    },
+    inLanguage: siteConfig.identity.language,
+    isPartOf: { "@id": `${siteRoot}#website` },
+    keywords: entry.data.tags,
+    mainEntityOfPage: { "@id": `${canonicalUrl}#webpage` },
+    publisher: { "@id": `${siteRoot}#publisher` },
     url: canonicalUrl,
-  };
+  });
 }
 
 /**
@@ -145,4 +179,12 @@ function authorJsonLd(
     name: author.displayName,
     url: absoluteUrl(author.href, site),
   };
+}
+
+function compactJsonLd(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, item]) => item !== undefined),
+  );
 }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -11,10 +11,12 @@ import { siteConfig } from "./site-config";
 
 /** Optional normalized metadata for article JSON-LD output. */
 interface ArticleBlogPostingJsonLdOptions {
+  about?: ReadonlyArray<Record<"@id", string>> | undefined;
   image?: string | undefined;
 }
 
 interface PublishableBlogPostingJsonLdOptions {
+  about?: ReadonlyArray<Record<"@id", string>> | undefined;
   authors?: readonly AuthorSummary[] | undefined;
   canonicalPath: string;
   fallbackAuthorName: string;
@@ -69,6 +71,7 @@ export function articleBlogPostingJsonLd(
   options: ArticleBlogPostingJsonLdOptions = {},
 ): Record<string, unknown> {
   return publishableBlogPostingJsonLd(article, site, {
+    about: options.about,
     authors,
     canonicalPath: articleUrl(article.id),
     fallbackAuthorName: authorName(article),
@@ -99,6 +102,10 @@ export function publishableBlogPostingJsonLd(
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     "@id": `${canonicalUrl}#article`,
+    about:
+      options.about === undefined || options.about.length === 0
+        ? undefined
+        : options.about,
     articleSection: options.section,
     author:
       options.authors !== undefined && options.authors.length > 0

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -195,8 +195,20 @@ export const siteConfigSchema = z
       .object({
         description: z.string().min(1),
         language: z.string().min(2),
+        locale: z.string().min(2).default("en_US"),
+        logo: pathOrUrlSchema.optional(),
         publisherName: z.string().min(1).optional(),
+        publisherType: z
+          .enum(["organization", "person"])
+          .default("organization"),
+        sameAs: z.array(z.string().url()).default([]),
         shortTitle: z.string().min(1).optional(),
+        themeColor: z
+          .string()
+          .regex(/^#[\da-f]{6}$/iu, {
+            message: "Expected a 6-digit hex color such as #b65a35.",
+          })
+          .optional(),
         timezone: z.string().min(1).optional(),
         title: z.string().min(1),
         url: z.string().url(),

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -11,6 +11,7 @@ import { titleWithSite } from "../lib/site-config";
   title={titleWithSite("Page Not Found")}
   description="The requested page could not be found."
   canonicalPath="/404/"
+  kind="not-found"
 >
   <PageFrame size="prose">
     <div class="grid gap-6">

--- a/src/pages/announcements/[...slug].astro
+++ b/src/pages/announcements/[...slug].astro
@@ -20,6 +20,7 @@ import {
   type AnnouncementEntry,
 } from "../../lib/routes";
 import { siteConfig } from "../../lib/site-config";
+import { semanticDetailsViewModel } from "../../lib/semantic-metadata";
 import { socialPreviewImageViewModel } from "../../lib/social-images";
 import { announcementStaticPaths } from "../../lib/static-paths";
 
@@ -42,6 +43,7 @@ const title = announcement.data.title;
 const description = announcement.data.description;
 const searchable =
   siteConfig.features.search && announcement.data.visibility.search;
+const semanticDetails = semanticDetailsViewModel(announcement.data.semantic);
 const fallbackSocialPreviewImage = await getSiteSocialFallbackImage();
 const socialPreviewImage = await socialPreviewImageViewModel({
   alt: announcement.data.imageAlt ?? title,
@@ -94,6 +96,7 @@ const socialPreviewImage = await socialPreviewImageViewModel({
         date={announcement.data.date}
         description={description}
         formattedDate={formatDate(announcement.data.date)}
+        semanticDetails={semanticDetails}
         title={title}
       />
       <ArticleProse data-article-prose>

--- a/src/pages/announcements/[...slug].astro
+++ b/src/pages/announcements/[...slug].astro
@@ -5,12 +5,16 @@ import { render } from "astro:content";
 import ArticleHeader from "../../components/articles/ArticleHeader.astro";
 import ArticleProse from "../../components/articles/ArticleProse.astro";
 import ReadingBody from "../../components/layout/ReadingBody.astro";
+import AnnouncementJsonLd from "../../components/seo/AnnouncementJsonLd.astro";
+import PublishableOpenGraphMeta from "../../components/seo/PublishableOpenGraphMeta.astro";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import {
   getAnnouncements,
   getSiteSocialFallbackImage,
 } from "../../lib/content";
+import { breadcrumbListJsonLd } from "../../lib/metadata";
 import {
+  announcementsIndexUrl,
   announcementUrl,
   formatDate,
   type AnnouncementEntry,
@@ -52,8 +56,33 @@ const socialPreviewImage = await socialPreviewImageViewModel({
   description={description}
   canonicalPath={announcementUrl(announcement.id)}
   image={socialPreviewImage}
+  kind="announcement"
+  structuredData={[
+    breadcrumbListJsonLd(
+      announcementUrl(announcement.id),
+      [
+        { href: "/", title: siteConfig.identity.title },
+        { href: announcementsIndexUrl(), title: "Announcements" },
+        { href: announcementUrl(announcement.id), title },
+      ],
+      Astro.site,
+    ),
+  ]}
   type="article"
 >
+  <AnnouncementJsonLd
+    slot="head"
+    announcement={announcement}
+    image={socialPreviewImage}
+  />
+  <PublishableOpenGraphMeta
+    slot="head"
+    author={announcement.data.author}
+    publishedAt={announcement.data.date}
+    section="Announcements"
+    tags={announcement.data.tags}
+    updatedAt={announcement.data.updated}
+  />
   <ReadingBody>
     <article
       class="grid w-full min-w-0 gap-8"

--- a/src/pages/announcements/index.astro
+++ b/src/pages/announcements/index.astro
@@ -4,22 +4,28 @@ import BrowsingBody from "../../components/layout/BrowsingBody.astro";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { announcementDirectoryListItems } from "../../lib/announcements";
 import { getAnnouncements } from "../../lib/content";
+import { itemListJsonLd } from "../../lib/metadata";
 import { announcementsIndexUrl, SITE_TITLE } from "../../lib/routes";
 import { titleWithSite } from "../../lib/site-config";
 
 const announcements = await getAnnouncements();
+const announcementItems = announcementDirectoryListItems(announcements);
 ---
 
 <BaseLayout
   title={titleWithSite("Announcements")}
   description={`Updates from ${SITE_TITLE}.`}
   canonicalPath={announcementsIndexUrl()}
+  kind="announcements-index"
+  structuredData={[
+    itemListJsonLd(announcementsIndexUrl(), announcementItems, Astro.site),
+  ]}
 >
   <BrowsingBody>
     <ArchiveListBlock
       title="Announcements"
       description={`Updates from ${SITE_TITLE}.`}
-      items={announcementDirectoryListItems(announcements)}
+      items={announcementItems}
     />
   </BrowsingBody>
 </BaseLayout>

--- a/src/pages/articles/all.astro
+++ b/src/pages/articles/all.astro
@@ -6,6 +6,7 @@ import { articleListItemsFromArchive } from "../../lib/article-list";
 import { articleArchiveItems } from "../../lib/archive";
 import { getAuthorEntries } from "../../lib/authors";
 import { getArticles, getCategories } from "../../lib/content";
+import { itemListJsonLd } from "../../lib/metadata";
 import { articlesArchiveUrl, SITE_TITLE } from "../../lib/routes";
 import { titleWithSite } from "../../lib/site-config";
 
@@ -22,6 +23,10 @@ const articleItems = articleListItemsFromArchive(archiveItems);
   title={titleWithSite("All Articles")}
   description={`Complete chronological article archive for ${SITE_TITLE}.`}
   canonicalPath={articlesArchiveUrl()}
+  kind="articles-archive"
+  structuredData={[
+    itemListJsonLd(articlesArchiveUrl(), articleItems, Astro.site),
+  ]}
 >
   <BrowsingBody>
     <ArchiveListBlock

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -10,6 +10,7 @@ import { articleListItemsFromArchive } from "../../lib/article-list";
 import { articleArchiveItems } from "../../lib/archive";
 import { getAuthorEntries } from "../../lib/authors";
 import { getArticles, getCategories } from "../../lib/content";
+import { itemListJsonLd } from "../../lib/metadata";
 import { sectionNavigationItems } from "../../lib/navigation";
 import {
   articlesArchiveUrl,
@@ -30,6 +31,8 @@ const categoryItems = sectionNavigationItems(categories, articlesIndexUrl());
   title={titleWithSite("Articles")}
   description={`Browse ${SITE_TITLE} by category, recent writing, and full archive.`}
   canonicalPath={articlesIndexUrl()}
+  kind="articles-index"
+  structuredData={[itemListJsonLd(articlesIndexUrl(), latestItems, Astro.site)]}
 >
   <BrowsingBody>
     <section class="grid gap-4">

--- a/src/pages/authors/[author].astro
+++ b/src/pages/authors/[author].astro
@@ -8,7 +8,12 @@ import { articleListItemsFromArchive } from "../../lib/article-list";
 import { articleArchiveItems } from "../../lib/archive";
 import { getAuthorEntries, getAuthorProfiles } from "../../lib/authors";
 import { getCategories } from "../../lib/content";
-import { SITE_TITLE } from "../../lib/routes";
+import {
+  breadcrumbListJsonLd,
+  itemListJsonLd,
+  profileEntityJsonLd,
+} from "../../lib/metadata";
+import { authorsIndexUrl, SITE_TITLE } from "../../lib/routes";
 import { titleWithSite } from "../../lib/site-config";
 
 /**
@@ -41,6 +46,32 @@ const description =
   title={titleWithSite(profile.displayName)}
   description={description}
   canonicalPath={profile.href}
+  kind="author-profile"
+  structuredData={[
+    breadcrumbListJsonLd(
+      profile.href,
+      [
+        { href: "/", title: "Home" },
+        { href: authorsIndexUrl(), title: "Authors" },
+        { href: profile.href, title: profile.displayName },
+      ],
+      Astro.site,
+    ),
+    profileEntityJsonLd(
+      {
+        description: profile.shortBio,
+        href: profile.href,
+        name: profile.displayName,
+        sameAs: [
+          ...(profile.website === undefined ? [] : [profile.website]),
+          ...profile.socials.map((social) => social.href),
+        ],
+        type: profile.type,
+      },
+      Astro.site,
+    ),
+    itemListJsonLd(profile.href, articleItems, Astro.site),
+  ]}
 >
   <BrowsingBody>
     <AuthorPage

--- a/src/pages/authors/index.astro
+++ b/src/pages/authors/index.astro
@@ -3,16 +3,24 @@ import AuthorsIndexPage from "../../components/authors/AuthorsIndexPage.astro";
 import BrowsingBody from "../../components/layout/BrowsingBody.astro";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { getAuthorProfiles } from "../../lib/authors";
+import { itemListJsonLd } from "../../lib/metadata";
 import { authorsIndexUrl, SITE_TITLE } from "../../lib/routes";
 import { titleWithSite } from "../../lib/site-config";
 
 const profiles = await getAuthorProfiles();
+const profileItems = profiles.map((profile) => ({
+  description: profile.shortBio,
+  href: profile.href,
+  title: profile.displayName,
+}));
 ---
 
 <BaseLayout
   title={titleWithSite("Authors")}
   description={`Browse contributors and collectives in ${SITE_TITLE} archive.`}
   canonicalPath={authorsIndexUrl()}
+  kind="author-index"
+  structuredData={[itemListJsonLd(authorsIndexUrl(), profileItems, Astro.site)]}
 >
   <BrowsingBody>
     <AuthorsIndexPage profiles={profiles} />

--- a/src/pages/bibliography.astro
+++ b/src/pages/bibliography.astro
@@ -6,6 +6,7 @@ import BrowsingBody from "../components/layout/BrowsingBody.astro";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { bibliographyEntriesFromArticleReferences } from "../lib/bibliography";
 import { getArticles } from "../lib/content";
+import { itemListJsonLd } from "../lib/metadata";
 import { bibliographyUrl, SITE_TITLE } from "../lib/routes";
 import { titleWithSite } from "../lib/site-config";
 import { articleReferencesFromFrontmatter } from "../remark-plugins/articleReferences";
@@ -22,12 +23,21 @@ const articleReferences = await Promise.all(
   }),
 );
 const entries = bibliographyEntriesFromArticleReferences(articleReferences);
+const bibliographyItems = entries.map((entry) => ({
+  description: entry.display.authors,
+  href: `${bibliographyUrl()}#${entry.id}`,
+  title: entry.display.title ?? entry.sourceText,
+}));
 ---
 
 <BaseLayout
   title={titleWithSite("Bibliography")}
   description={`Sources cited by articles in ${SITE_TITLE}.`}
   canonicalPath={bibliographyUrl()}
+  kind="bibliography"
+  structuredData={[
+    itemListJsonLd(bibliographyUrl(), bibliographyItems, Astro.site),
+  ]}
 >
   <BrowsingBody>
     <BibliographyPage entries={entries} />

--- a/src/pages/catalog/[...path].astro
+++ b/src/pages/catalog/[...path].astro
@@ -20,6 +20,7 @@ export function getStaticPaths() {
   title={catalogMetadata.title}
   description={catalogMetadata.description}
   canonicalPath="/catalog/"
+  kind="catalog"
 >
   <ComponentCatalog />
 </BaseLayout>

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -6,7 +6,8 @@ import { articleListItemsFromArchive } from "../../lib/article-list";
 import { articleArchiveItems } from "../../lib/archive";
 import { getAuthorEntries } from "../../lib/authors";
 import { getCategories } from "../../lib/content";
-import { categoryUrl } from "../../lib/routes";
+import { breadcrumbListJsonLd, itemListJsonLd } from "../../lib/metadata";
+import { categoriesIndexUrl, categoryUrl } from "../../lib/routes";
 import { titleWithSite } from "../../lib/site-config";
 import { categoryStaticPaths } from "../../lib/static-paths";
 
@@ -31,6 +32,19 @@ const categoryItems = articleListItemsFromArchive(
   description={category.description ??
     `Articles filed under ${category.title}.`}
   canonicalPath={categoryUrl(category.slug)}
+  kind="category-detail"
+  structuredData={[
+    breadcrumbListJsonLd(
+      categoryUrl(category.slug),
+      [
+        { href: "/", title: "Home" },
+        { href: categoriesIndexUrl(), title: "Categories" },
+        { href: categoryUrl(category.slug), title: category.title },
+      ],
+      Astro.site,
+    ),
+    itemListJsonLd(categoryUrl(category.slug), categoryItems, Astro.site),
+  ]}
 >
   <BrowsingBody>
     <ArchiveListBlock

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -3,6 +3,7 @@ import CategoryOverviewBlock from "../../components/blocks/CategoryOverviewBlock
 import BrowsingBody from "../../components/layout/BrowsingBody.astro";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { getCategories } from "../../lib/content";
+import { itemListJsonLd } from "../../lib/metadata";
 import { sectionNavigationItems } from "../../lib/navigation";
 import { categoriesIndexUrl } from "../../lib/routes";
 import { titleWithSite } from "../../lib/site-config";
@@ -17,6 +18,10 @@ const categoryItems = sectionNavigationItems(
   title={titleWithSite("Categories")}
   description="Browse articles by category."
   canonicalPath={categoriesIndexUrl()}
+  kind="category-index"
+  structuredData={[
+    itemListJsonLd(categoriesIndexUrl(), categoryItems, Astro.site),
+  ]}
 >
   <BrowsingBody>
     <CategoryOverviewBlock

--- a/src/pages/collections/[collection].astro
+++ b/src/pages/collections/[collection].astro
@@ -19,7 +19,8 @@ import {
   publishableFromArticleArchive,
   publishableIndex,
 } from "../../lib/publishable";
-import { collectionUrl } from "../../lib/routes";
+import { breadcrumbListJsonLd, itemListJsonLd } from "../../lib/metadata";
+import { collectionsIndexUrl, collectionUrl } from "../../lib/routes";
 import { siteConfig, titleWithSite } from "../../lib/site-config";
 import { collectionStaticPaths } from "../../lib/static-paths";
 
@@ -61,6 +62,19 @@ const description =
   title={titleWithSite(`${title} | Collections`)}
   description={description}
   canonicalPath={collectionUrl(collection.id)}
+  kind="collection-detail"
+  structuredData={[
+    breadcrumbListJsonLd(
+      collectionUrl(collection.id),
+      [
+        { href: "/", title: "Home" },
+        { href: collectionsIndexUrl(), title: "Collections" },
+        { href: collectionUrl(collection.id), title },
+      ],
+      Astro.site,
+    ),
+    itemListJsonLd(collectionUrl(collection.id), collectionItems, Astro.site),
+  ]}
 >
   <BrowsingBody>
     <ArchiveListBlock

--- a/src/pages/collections/index.astro
+++ b/src/pages/collections/index.astro
@@ -8,6 +8,7 @@ import {
   collectionUrl,
   SITE_TITLE,
 } from "../../lib/routes";
+import { itemListJsonLd } from "../../lib/metadata";
 import { titleWithSite } from "../../lib/site-config";
 
 const collectionItems = (await getEditorialCollections()).map((collection) => ({
@@ -22,6 +23,10 @@ const collectionItems = (await getEditorialCollections()).map((collection) => ({
   title={titleWithSite("Collections")}
   description={`Curated article and announcement collections from ${SITE_TITLE}.`}
   canonicalPath={collectionsIndexUrl()}
+  kind="collection-index"
+  structuredData={[
+    itemListJsonLd(collectionsIndexUrl(), collectionItems, Astro.site),
+  ]}
 >
   <BrowsingBody>
     <TermOverviewBlock

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,6 +19,7 @@ import {
   getEditorialCollections,
 } from "../lib/content";
 import { homePageRouteViewModel } from "../lib/home";
+import { itemListJsonLd } from "../lib/metadata";
 import { sectionNavigationItems } from "../lib/navigation";
 import { siteConfig } from "../lib/site-config";
 
@@ -52,6 +53,10 @@ const homeView = homePageRouteViewModel({
   title={homeView.title}
   description={homeView.description}
   canonicalPath={homeView.canonicalPath}
+  kind="home"
+  structuredData={[
+    itemListJsonLd(homeView.canonicalPath, homeView.recent.items, Astro.site),
+  ]}
 >
   <BrowsingBody width="wide" padding="snug">
     <div class="grid min-w-0 gap-1" data-home-read-lead-group>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -10,6 +10,7 @@ import { titleWithSite } from "../lib/site-config";
   title={titleWithSite("Search")}
   description={`Search ${SITE_TITLE} archive.`}
   canonicalPath={searchUrl()}
+  kind="search"
 >
   <BrowsingBody>
     <SearchResultsBlock />

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -6,6 +6,8 @@ import { articleListItemsFromArchive } from "../../lib/article-list";
 import { articleArchiveItems } from "../../lib/archive";
 import { getAuthorEntries } from "../../lib/authors";
 import { getCategories, getTags } from "../../lib/content";
+import { breadcrumbListJsonLd, itemListJsonLd } from "../../lib/metadata";
+import { tagsIndexUrl } from "../../lib/routes";
 import { titleWithSite } from "../../lib/site-config";
 import { tagStaticPaths } from "../../lib/static-paths";
 
@@ -31,6 +33,19 @@ const description = `Articles tagged ${tag.label}.`;
   title={titleWithSite(`${tag.label} | Tags`)}
   description={description}
   canonicalPath={tag.href}
+  kind="tag-detail"
+  structuredData={[
+    breadcrumbListJsonLd(
+      tag.href,
+      [
+        { href: "/", title: "Home" },
+        { href: tagsIndexUrl(), title: "Tags" },
+        { href: tag.href, title: tag.label },
+      ],
+      Astro.site,
+    ),
+    itemListJsonLd(tag.href, tagItems, Astro.site),
+  ]}
 >
   <BrowsingBody>
     <ArchiveListBlock

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -3,6 +3,7 @@ import TermOverviewBlock from "../../components/blocks/TermOverviewBlock.astro";
 import BrowsingBody from "../../components/layout/BrowsingBody.astro";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { getTags } from "../../lib/content";
+import { itemListJsonLd } from "../../lib/metadata";
 import { tagsIndexUrl } from "../../lib/routes";
 import { titleWithSite } from "../../lib/site-config";
 
@@ -17,6 +18,8 @@ const tagItems = (await getTags()).map((tag) => ({
   title={titleWithSite("Tags")}
   description="Browse articles by tag."
   canonicalPath={tagsIndexUrl()}
+  kind="tag-index"
+  structuredData={[itemListJsonLd(tagsIndexUrl(), tagItems, Astro.site)]}
 >
   <BrowsingBody>
     <TermOverviewBlock

--- a/tests/a11y/a11y.pw.ts
+++ b/tests/a11y/a11y.pw.ts
@@ -1,13 +1,22 @@
 import { AxeBuilder } from "@axe-core/playwright";
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
+
+type AxeResult = Awaited<
+  ReturnType<InstanceType<typeof AxeBuilder>["analyze"]>
+>["violations"][number];
 
 const routes = [
   "/",
+  "/announcements/",
   "/articles/",
   "/articles/gamergate-as-metagaming/",
+  "/authors/",
   "/bibliography/",
   "/categories/",
   "/categories/history/",
+  "/collections/",
+  "/collections/start-here/",
+  "/tags/",
   "/about/",
   "/search/",
 ];
@@ -26,7 +35,75 @@ for (const route of routes) {
       (violation) =>
         violation.impact === "serious" || violation.impact === "critical",
     );
+    const { firstPartyViolations } = await partitionAccessibilityViolations(
+      page,
+      severeViolations,
+    );
 
-    expect(severeViolations).toEqual([]);
+    expect(firstPartyViolations).toEqual([]);
   });
+}
+
+async function partitionAccessibilityViolations(
+  page: Page,
+  violations: readonly AxeResult[],
+): Promise<{
+  externalFrameViolations: AxeResult[];
+  firstPartyViolations: AxeResult[];
+}> {
+  const classified = await Promise.all(
+    violations.map(async (violation) => ({
+      isExternalFrameContent: await isExternalFrameContentViolation(
+        page,
+        violation,
+      ),
+      violation,
+    })),
+  );
+
+  return {
+    externalFrameViolations: classified
+      .filter(({ isExternalFrameContent }) => isExternalFrameContent)
+      .map(({ violation }) => violation),
+    firstPartyViolations: classified
+      .filter(({ isExternalFrameContent }) => !isExternalFrameContent)
+      .map(({ violation }) => violation),
+  };
+}
+
+async function isExternalFrameContentViolation(
+  page: Page,
+  violation: AxeResult,
+): Promise<boolean> {
+  if (violation.nodes.length === 0) {
+    return false;
+  }
+
+  const nodeResults = await Promise.all(
+    violation.nodes.map(async (node) => {
+      const frameSelector = node.target[0];
+      if (node.target.length < 2 || typeof frameSelector !== "string") {
+        return false;
+      }
+
+      const frame = page.locator(frameSelector).first();
+      if ((await frame.count()) === 0) {
+        return false;
+      }
+
+      return frame.evaluate((element) => {
+        if (!(element instanceof HTMLIFrameElement)) {
+          return false;
+        }
+
+        try {
+          return !element.src.startsWith(`${window.location.origin}/`);
+        } catch {
+          return false;
+        }
+      });
+    }),
+  );
+
+  return nodeResults.every(Boolean);
 }

--- a/tests/config/static-public-files.test.ts
+++ b/tests/config/static-public-files.test.ts
@@ -1,0 +1,34 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+describe("static public files", () => {
+  test("serves fingerprinted Astro assets with long-lived immutable caching", async () => {
+    const headers = await readFile("site/public/_headers", "utf8");
+
+    expect(headers).toContain("/_astro/*");
+    expect(headers).toContain(
+      "Cache-Control: public, max-age=31556952, immutable",
+    );
+  });
+
+  test("publishes a valid traffic-advice policy for private prefetch proxies", async () => {
+    const policyText = await readFile(
+      "site/public/.well-known/traffic-advice",
+      "utf8",
+    );
+    const policy = JSON.parse(policyText) as unknown;
+
+    expect(policy).toEqual([{ fraction: 1, user_agent: "prefetch-proxy" }]);
+  });
+
+  test("serves traffic-advice with an explicit Cloudflare static asset header", async () => {
+    const headers = await readFile("site/public/_headers", "utf8");
+
+    expect(headers).toContain("/.well-known/traffic-advice");
+    expect(headers).toContain(
+      "Content-Type: application/trafficadvice+json; charset=utf-8",
+    );
+    expect(headers).toContain("X-Content-Type-Options: nosniff");
+  });
+});

--- a/tests/lib/legacy-redirects.test.ts
+++ b/tests/lib/legacy-redirects.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, test } from "bun:test";
 import matter from "gray-matter";
 
 import {
+  collectCloudflareRedirectRules,
   collectLegacyRedirectRules,
   defaultLegacyRedirectSources,
 } from "../../scripts/build/generate-cloudflare-redirects";
@@ -22,6 +23,16 @@ const publishableSources = [
   },
 ] as const;
 const publishablePattern = /\.mdx?$/i;
+const rootCategoryRedirects = {
+  "/aesthetics/": "/categories/aesthetics/",
+  "/game-studies/": "/categories/game-studies/",
+  "/history/": "/categories/history/",
+  "/irony/": "/categories/irony/",
+  "/memeculture/": "/categories/memeculture/",
+  "/metamemetics/": "/categories/metamemetics/",
+  "/philosophy/": "/categories/philosophy/",
+  "/politics/": "/categories/politics/",
+} as const;
 
 async function configRedirects() {
   // eslint-disable-next-line no-unsanitized/method -- Fixed local config path, not user-controlled input.
@@ -140,13 +151,16 @@ function withTrailingSlash(value: string) {
 }
 
 describe("legacy redirects", () => {
-  test("Astro redirects match publishable legacy permalink frontmatter", async () => {
-    expect(await configRedirects()).toEqual(
+  test("Astro redirects include publishable legacy permalink frontmatter and root categories", async () => {
+    const redirects = await configRedirects();
+
+    expect(redirects).toMatchObject(
       await expectedRedirectsFromPublishableFrontmatter(),
     );
+    expect(redirects).toMatchObject(rootCategoryRedirects);
   });
 
-  test("Cloudflare redirects match publishable legacy permalink frontmatter", async () => {
+  test("content-derived Cloudflare redirects match publishable legacy permalink frontmatter", async () => {
     expect(
       Object.fromEntries(
         (await collectLegacyRedirectRules(defaultLegacyRedirectSources())).map(
@@ -154,5 +168,15 @@ describe("legacy redirects", () => {
         ),
       ),
     ).toEqual(await expectedRedirectsFromPublishableFrontmatter());
+  });
+
+  test("Cloudflare redirects include site-owned root category redirects", async () => {
+    expect(
+      Object.fromEntries(
+        (
+          await collectCloudflareRedirectRules(defaultLegacyRedirectSources())
+        ).map((rule) => [rule.source, rule.destination]),
+      ),
+    ).toMatchObject(rootCategoryRedirects);
   });
 });

--- a/tests/lib/seo.test.ts
+++ b/tests/lib/seo.test.ts
@@ -46,9 +46,18 @@ describe("SEO helpers", () => {
         name: "Seong-Young Her",
       },
       description: "A short article description.",
+      inLanguage: "en",
+      isPartOf: {
+        "@id": "https://example.com/#website",
+      },
       headline: "Example Article",
       keywords: ["philosophy", "quotes"],
-      mainEntityOfPage: "https://example.com/articles/example-article/",
+      mainEntityOfPage: {
+        "@id": "https://example.com/articles/example-article/#webpage",
+      },
+      publisher: {
+        "@id": "https://example.com/#publisher",
+      },
       url: "https://example.com/articles/example-article/",
     });
   });

--- a/tests/scripts/build/build-verifier.test.ts
+++ b/tests/scripts/build/build-verifier.test.ts
@@ -1411,6 +1411,66 @@ describe("build verifier helpers", () => {
       expect(result.issues.unexpectedDatedPages).toEqual([]);
     }));
 
+  test("allows Astro generated root redirect fallback pages", async () =>
+    withTempRoot(async (root) => {
+      await writeText(root, "src/content/categories/history.json", "{}");
+      await writeText(
+        root,
+        "src/content/articles/history/published.md",
+        "---\ntitle: Published\n---\n",
+      );
+
+      await writeText(root, "dist/index.html", "");
+      await writeText(root, "dist/404.html", "");
+      await writeText(root, "dist/about/index.html", "");
+      await writeText(root, "dist/announcements/index.html", "");
+      await writeText(root, "dist/authors/index.html", "");
+      await writeText(root, "dist/articles/index.html", "");
+      await writeText(root, "dist/articles/all/index.html", "");
+      await writeText(root, "dist/bibliography/index.html", "");
+      await writeText(
+        root,
+        "dist/articles/published/index.html",
+        articleHtmlFixture("published"),
+      );
+      await writeArticlePdf(root, "published");
+      await writeText(root, "dist/categories/index.html", "");
+      await writeText(root, "dist/collections/index.html", "");
+      await writeText(root, "dist/tags/index.html", "");
+      await writeText(root, "dist/search/index.html", "");
+      await writeText(root, "dist/categories/history/index.html", "");
+      await writeText(root, "dist/feed.xml", "<feed>published</feed>");
+      await writeText(root, "dist/sitemap-index.xml", "<sitemap />");
+      await writeText(root, "dist/pagefind/pagefind.js", "");
+      await writeText(
+        root,
+        "dist/_astro/social-preview.jpg",
+        "small social jpg",
+      );
+      await writeText(
+        root,
+        "dist/memeculture/index.html",
+        '<!doctype html><title>Redirecting to: /categories/memeculture/</title><meta http-equiv="refresh" content="0;url=/categories/memeculture/"><meta name="robots" content="noindex"><link rel="canonical" href="https://thephilosophersmeme.com/categories/memeculture/"><body><a href="/categories/memeculture/">Redirecting from <code>/memeculture/</code> to <code>/categories/memeculture/</code></a></body>',
+      );
+
+      const result = await verifyBuild({
+        articleDir: path.join(root, "src/content/articles"),
+        categoryDir: path.join(root, "src/content/categories"),
+        distDir: path.join(root, "dist"),
+        expectedRedirects: {
+          "/memeculture/": "/categories/memeculture/",
+        },
+      });
+
+      expect(result.issues.invalidLegacyRedirects).toEqual([]);
+      expect(result.issues.metadataIssues).not.toContain(
+        "memeculture/index.html: missing meta description",
+      );
+      expect(result.issues.metadataIssues).not.toContain(
+        "memeculture/index.html: missing JSON-LD",
+      );
+    }));
+
   test("rejects dated pages that are not Astro redirect fallbacks", async () =>
     withTempRoot(async (root) => {
       await writeText(root, "src/content/categories/history.json", "{}");

--- a/tests/scripts/build/build-verifier.test.ts
+++ b/tests/scripts/build/build-verifier.test.ts
@@ -934,6 +934,40 @@ describe("build verifier helpers", () => {
       ]);
     }));
 
+  test("accepts article JSON-LD image metadata from a graph node", async () =>
+    withTempRoot(async (root) => {
+      const socialImage =
+        "https://thephilosophersmeme.com/_astro/social-preview.jpg";
+
+      await writeText(root, "src/content/categories/history.json", "{}");
+      await writeText(
+        root,
+        "src/content/articles/history/published.md",
+        "---\ntitle: Published\nauthor: Test Author\n---\n",
+      );
+      await writeRequiredDistShell(root);
+      await writeText(
+        root,
+        "dist/articles/published/index.html",
+        articleHtmlFixture("published", { authors: ["Test Author"] }).replace(
+          `<script type="application/ld+json">{"@type":"BlogPosting","image":"${socialImage}"}</script>`,
+          `<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"BlogPosting","image":"${socialImage}"},{"@type":"Review","name":"Extra semantic node"}]}</script>`,
+        ),
+      );
+      await writeArticlePdf(root, "published", {
+        authors: ["Test Author"],
+      });
+
+      const result = await verifyBuild({
+        articleDir: path.join(root, "src/content/articles"),
+        categoryDir: path.join(root, "src/content/categories"),
+        distDir: path.join(root, "dist"),
+      });
+
+      expect(result.issues.missingArticleJsonLd).toEqual([]);
+      expect(result.issues.socialImageIssues).toEqual([]);
+    }));
+
   test("reports oversized generated social preview image files", async () =>
     withTempRoot(async (root) => {
       await writeText(root, "src/content/categories/history.json", "{}");

--- a/tests/scripts/build/build-verifier.test.ts
+++ b/tests/scripts/build/build-verifier.test.ts
@@ -97,21 +97,115 @@ async function writeArticlePdf(
   }
 }
 
+function pageHtmlFixture(
+  relativePath: string,
+  body = "",
+  { includeShareMeta = true, noindex = false, title = "Test Page" } = {},
+) {
+  const pathWithLeadingSlash = `/${relativePath}`
+    .replace(/\/index\.html$/, "/")
+    .replace(/\/404\.html$/, "/404/");
+  const canonical = `https://thephilosophersmeme.com${pathWithLeadingSlash}`;
+  const socialImage =
+    "https://thephilosophersmeme.com/_astro/social-preview.jpg";
+  const robots = noindex ? "noindex, follow" : "index, follow";
+
+  const shareMeta = includeShareMeta
+    ? [
+        '<meta property="og:site_name" content="The Philosopher\'s Meme">',
+        '<meta property="og:locale" content="en_US">',
+        '<meta property="og:type" content="website">',
+        `<meta property="og:title" content="${title}">`,
+        '<meta property="og:description" content="Test description">',
+        `<meta property="og:url" content="${canonical}">`,
+        `<meta property="og:image" content="${socialImage}">`,
+        '<meta name="twitter:card" content="summary_large_image">',
+        `<meta name="twitter:title" content="${title}">`,
+        '<meta name="twitter:description" content="Test description">',
+        `<meta name="twitter:image" content="${socialImage}">`,
+      ]
+    : [];
+
+  return [
+    "<!doctype html><html><head>",
+    `<title>${title}</title>`,
+    `<link rel="canonical" href="${canonical}">`,
+    '<meta name="description" content="Test description">',
+    `<meta name="robots" content="${robots}">`,
+    ...shareMeta,
+    '<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage"}</script>',
+    "</head><body>",
+    body,
+    "</body></html>",
+  ].join("");
+}
+
 async function writeRequiredDistShell(root: string) {
   await writeText(root, "dist/_astro/social-preview.jpg", "small social jpg");
-  await writeText(root, "dist/index.html", "");
-  await writeText(root, "dist/404.html", "");
-  await writeText(root, "dist/about/index.html", "");
-  await writeText(root, "dist/announcements/index.html", "");
-  await writeText(root, "dist/authors/index.html", "");
-  await writeText(root, "dist/articles/index.html", "");
-  await writeText(root, "dist/articles/all/index.html", "");
-  await writeText(root, "dist/bibliography/index.html", "");
-  await writeText(root, "dist/categories/index.html", "");
-  await writeText(root, "dist/collections/index.html", "");
-  await writeText(root, "dist/tags/index.html", "");
-  await writeText(root, "dist/search/index.html", "");
-  await writeText(root, "dist/categories/history/index.html", "");
+  await writeText(root, "dist/index.html", pageHtmlFixture("index.html"));
+  await writeText(
+    root,
+    "dist/404.html",
+    pageHtmlFixture("404.html", "", { noindex: true, title: "Not Found" }),
+  );
+  await writeText(
+    root,
+    "dist/about/index.html",
+    pageHtmlFixture("about/index.html"),
+  );
+  await writeText(
+    root,
+    "dist/announcements/index.html",
+    pageHtmlFixture("announcements/index.html"),
+  );
+  await writeText(
+    root,
+    "dist/authors/index.html",
+    pageHtmlFixture("authors/index.html"),
+  );
+  await writeText(
+    root,
+    "dist/articles/index.html",
+    pageHtmlFixture("articles/index.html"),
+  );
+  await writeText(
+    root,
+    "dist/articles/all/index.html",
+    pageHtmlFixture("articles/all/index.html"),
+  );
+  await writeText(
+    root,
+    "dist/bibliography/index.html",
+    pageHtmlFixture("bibliography/index.html"),
+  );
+  await writeText(
+    root,
+    "dist/categories/index.html",
+    pageHtmlFixture("categories/index.html"),
+  );
+  await writeText(
+    root,
+    "dist/collections/index.html",
+    pageHtmlFixture("collections/index.html"),
+  );
+  await writeText(
+    root,
+    "dist/tags/index.html",
+    pageHtmlFixture("tags/index.html"),
+  );
+  await writeText(
+    root,
+    "dist/search/index.html",
+    pageHtmlFixture("search/index.html", "", {
+      noindex: true,
+      title: "Search",
+    }),
+  );
+  await writeText(
+    root,
+    "dist/categories/history/index.html",
+    pageHtmlFixture("categories/history/index.html"),
+  );
   await writeText(root, "dist/feed.xml", "<feed>published</feed>");
   await writeText(root, "dist/sitemap-index.xml", "<sitemap />");
   await writeText(root, "dist/pagefind/pagefind.js", "");
@@ -134,27 +228,40 @@ function articleHtmlFixture(
   const socialImage =
     "https://thephilosophersmeme.com/_astro/social-preview.jpg";
 
-  return [
-    `<script type="application/ld+json">{"@type":"BlogPosting","image":"${socialImage}"}</script>`,
-    `<meta property="og:image" content="${socialImage}">`,
-    '<meta property="og:image:width" content="1200">',
-    '<meta property="og:image:height" content="630">',
-    '<meta property="og:image:type" content="image/jpeg">',
-    `<meta name="twitter:image" content="${socialImage}">`,
-    `<meta name="citation_title" content="${title}">`,
-    ...authors.map(
-      (author) => `<meta name="citation_author" content="${author}">`,
-    ),
-    date === undefined
-      ? ""
-      : `<meta name="citation_publication_date" content="${date}">`,
-    includePdf
-      ? `<meta name="citation_pdf_url" content="https://thephilosophersmeme.com/articles/${slug}/${slug}.pdf">`
-      : "",
-    includePdf
-      ? `<a href="/articles/${slug}/${slug}.pdf" data-article-pdf-link>Save PDF</a>`
-      : "",
-  ].join("");
+  return pageHtmlFixture(
+    `articles/${slug}/index.html`,
+    [
+      `<script type="application/ld+json">{"@type":"BlogPosting","image":"${socialImage}"}</script>`,
+      '<meta property="og:site_name" content="The Philosopher\'s Meme">',
+      '<meta property="og:locale" content="en_US">',
+      '<meta property="og:type" content="article">',
+      `<meta property="og:title" content="${title}">`,
+      '<meta property="og:description" content="Test description">',
+      `<meta property="og:url" content="https://thephilosophersmeme.com/articles/${slug}/">`,
+      `<meta property="og:image" content="${socialImage}">`,
+      '<meta property="og:image:width" content="1200">',
+      '<meta property="og:image:height" content="630">',
+      '<meta property="og:image:type" content="image/jpeg">',
+      '<meta name="twitter:card" content="summary_large_image">',
+      `<meta name="twitter:title" content="${title}">`,
+      '<meta name="twitter:description" content="Test description">',
+      `<meta name="twitter:image" content="${socialImage}">`,
+      `<meta name="citation_title" content="${title}">`,
+      ...authors.map(
+        (author) => `<meta name="citation_author" content="${author}">`,
+      ),
+      date === undefined
+        ? ""
+        : `<meta name="citation_publication_date" content="${date}">`,
+      includePdf
+        ? `<meta name="citation_pdf_url" content="https://thephilosophersmeme.com/articles/${slug}/${slug}.pdf">`
+        : "",
+      includePdf
+        ? `<a href="/articles/${slug}/${slug}.pdf" data-article-pdf-link>Save PDF</a>`
+        : "",
+    ].join(""),
+    { includeShareMeta: false, title },
+  );
 }
 
 const astroPrefetchRuntimeFixture =
@@ -473,6 +580,8 @@ describe("build verifier helpers", () => {
           catalogLeaks: [],
           draftLeaks: [],
           invalidLegacyRedirects: [],
+          imageAltIssues: [],
+          metadataIssues: [],
           missingArticleJsonLd: [],
           missingLegacyRedirects: [],
           missingRequired: ["articles/example/index.html"],
@@ -499,6 +608,10 @@ describe("build verifier helpers", () => {
         catalogLeaks: ["catalog/"],
         draftLeaks: ["feed.xml -> draft-post"],
         invalidLegacyRedirects: ["2022/01/01/post/index.html: invalid"],
+        imageAltIssues: [
+          "articles/post/index.html: /image.webp is missing alt",
+        ],
+        metadataIssues: ["index.html: missing meta description"],
         missingArticleJsonLd: ["articles/post/index.html"],
         missingLegacyRedirects: ["/2022/01/01/post/ -> /articles/post/"],
         missingRequired: ["feed.xml"],
@@ -514,6 +627,8 @@ describe("build verifier helpers", () => {
     expect(report).toContain("Article PDF issues:");
     expect(report).toContain("Missing legacy redirects:");
     expect(report).toContain("Invalid legacy redirects:");
+    expect(report).toContain("Metadata issues:");
+    expect(report).toContain("Image alt issues:");
     expect(report).toContain("Broken links:");
     expect(report).toContain("Unexpected component catalog output:");
     expect(report).toContain("Article count mismatch:");
@@ -543,15 +658,46 @@ describe("build verifier helpers", () => {
       await writeText(
         root,
         "dist/index.html",
-        '<a href="/articles/published/">Published</a>',
+        pageHtmlFixture(
+          "index.html",
+          '<a href="/articles/published/">Published</a>',
+        ),
       );
-      await writeText(root, "dist/404.html", "");
-      await writeText(root, "dist/about/index.html", "");
-      await writeText(root, "dist/announcements/index.html", "");
-      await writeText(root, "dist/authors/index.html", "");
-      await writeText(root, "dist/articles/index.html", "");
-      await writeText(root, "dist/articles/all/index.html", "");
-      await writeText(root, "dist/bibliography/index.html", "");
+      await writeText(
+        root,
+        "dist/404.html",
+        pageHtmlFixture("404.html", "", { noindex: true, title: "Not Found" }),
+      );
+      await writeText(
+        root,
+        "dist/about/index.html",
+        pageHtmlFixture("about/index.html"),
+      );
+      await writeText(
+        root,
+        "dist/announcements/index.html",
+        pageHtmlFixture("announcements/index.html"),
+      );
+      await writeText(
+        root,
+        "dist/authors/index.html",
+        pageHtmlFixture("authors/index.html"),
+      );
+      await writeText(
+        root,
+        "dist/articles/index.html",
+        pageHtmlFixture("articles/index.html"),
+      );
+      await writeText(
+        root,
+        "dist/articles/all/index.html",
+        pageHtmlFixture("articles/all/index.html"),
+      );
+      await writeText(
+        root,
+        "dist/bibliography/index.html",
+        pageHtmlFixture("bibliography/index.html"),
+      );
       await writeText(
         root,
         "dist/articles/published/index.html",
@@ -563,11 +709,34 @@ describe("build verifier helpers", () => {
         "small social jpg",
       );
       await writeArticlePdf(root, "published");
-      await writeText(root, "dist/categories/index.html", "");
-      await writeText(root, "dist/collections/index.html", "");
-      await writeText(root, "dist/tags/index.html", "");
-      await writeText(root, "dist/search/index.html", "");
-      await writeText(root, "dist/categories/history/index.html", "");
+      await writeText(
+        root,
+        "dist/categories/index.html",
+        pageHtmlFixture("categories/index.html"),
+      );
+      await writeText(
+        root,
+        "dist/collections/index.html",
+        pageHtmlFixture("collections/index.html"),
+      );
+      await writeText(
+        root,
+        "dist/tags/index.html",
+        pageHtmlFixture("tags/index.html"),
+      );
+      await writeText(
+        root,
+        "dist/search/index.html",
+        pageHtmlFixture("search/index.html", "", {
+          noindex: true,
+          title: "Search",
+        }),
+      );
+      await writeText(
+        root,
+        "dist/categories/history/index.html",
+        pageHtmlFixture("categories/history/index.html"),
+      );
       await writeText(root, "dist/feed.xml", "<feed>published</feed>");
       await writeText(root, "dist/sitemap-index.xml", "<sitemap />");
       await writeText(root, "dist/pagefind/pagefind.js", "");
@@ -894,33 +1063,13 @@ describe("build verifier helpers", () => {
             "---\ntitle: Published\n---\n",
           );
 
-          await writeText(root, "dist/index.html", "");
-          await writeText(root, "dist/404.html", "");
-          await writeText(root, "dist/about/index.html", "");
-          await writeText(root, "dist/announcements/index.html", "");
-          await writeText(root, "dist/authors/index.html", "");
-          await writeText(root, "dist/articles/index.html", "");
-          await writeText(root, "dist/articles/all/index.html", "");
-          await writeText(root, "dist/bibliography/index.html", "");
+          await writeRequiredDistShell(root);
           await writeText(
             root,
             "dist/articles/published/index.html",
             articleHtmlFixture("published"),
           );
           await writeArticlePdf(root, "published");
-          await writeText(root, "dist/categories/index.html", "");
-          await writeText(root, "dist/collections/index.html", "");
-          await writeText(root, "dist/tags/index.html", "");
-          await writeText(root, "dist/search/index.html", "");
-          await writeText(root, "dist/categories/history/index.html", "");
-          await writeText(root, "dist/feed.xml", "<feed>published</feed>");
-          await writeText(root, "dist/sitemap-index.xml", "<sitemap />");
-          await writeText(root, "dist/pagefind/pagefind.js", "");
-          await writeText(
-            root,
-            "dist/_astro/social-preview.jpg",
-            "small social jpg",
-          );
 
           const exitCode = await runBuildVerificationCli(["--quiet"], root);
 

--- a/tests/scripts/build/generate-cloudflare-redirects.test.ts
+++ b/tests/scripts/build/generate-cloudflare-redirects.test.ts
@@ -58,13 +58,14 @@ describe("Cloudflare redirect generation", () => {
     const result = await generateCloudflareRedirects({
       outputDir,
       quiet: true,
+      siteRedirects: {},
       sources: sources(root),
     });
 
     expect(result.count).toBe(2);
     expect(await readFile(path.join(outputDir, "_redirects"), "utf8")).toBe(
       [
-        "# Generated from article legacyPermalink metadata. Do not edit by hand.",
+        "# Generated from site redirects and article legacyPermalink metadata. Do not edit by hand.",
         "/2021/11/30/what-is-a-meme/ /articles/what-is-a-meme/ 301",
         "/announcements/discord/ /announcements/discord-community/ 301",
         "",
@@ -79,10 +80,104 @@ describe("Cloudflare redirect generation", () => {
       ]),
     ).toBe(
       [
-        "# Generated from article legacyPermalink metadata. Do not edit by hand.",
+        "# Generated from site redirects and article legacyPermalink metadata. Do not edit by hand.",
         "/2020/example/ /articles/example/ 301",
         "",
       ].join("\n"),
+    );
+  });
+
+  test("merges hand-written site redirects into generated output", async () => {
+    const root = await testRoot();
+    await writeText(
+      root,
+      "site/content/articles/culture/what-is-a-meme.md",
+      "---\ntitle: What Is A Meme?\nlegacyPermalink: 2021/11/30/what-is-a-meme\n---\n",
+    );
+    await mkdir(path.join(root, "site/content/announcements"), {
+      recursive: true,
+    });
+
+    const outputDir = path.join(root, "dist");
+    const result = await generateCloudflareRedirects({
+      outputDir,
+      quiet: true,
+      siteRedirects: {
+        "/memeculture/": "/categories/memeculture/",
+      },
+      sources: sources(root),
+    });
+
+    expect(result.count).toBe(2);
+    expect(await readFile(path.join(outputDir, "_redirects"), "utf8")).toBe(
+      [
+        "# Generated from site redirects and article legacyPermalink metadata. Do not edit by hand.",
+        "/2021/11/30/what-is-a-meme/ /articles/what-is-a-meme/ 301",
+        "/memeculture/ /categories/memeculture/ 301",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  test("deduplicates matching hand-written and generated redirects", async () => {
+    const root = await testRoot();
+    await writeText(
+      root,
+      "site/content/articles/culture/what-is-a-meme.md",
+      "---\ntitle: What Is A Meme?\nlegacyPermalink: 2021/11/30/what-is-a-meme\n---\n",
+    );
+    await mkdir(path.join(root, "site/content/announcements"), {
+      recursive: true,
+    });
+
+    const outputDir = path.join(root, "dist");
+    const result = await generateCloudflareRedirects({
+      outputDir,
+      quiet: true,
+      siteRedirects: {
+        "/2021/11/30/what-is-a-meme/": "/articles/what-is-a-meme/",
+      },
+      sources: sources(root),
+    });
+
+    expect(result.count).toBe(1);
+    expect(await readFile(path.join(outputDir, "_redirects"), "utf8")).toBe(
+      [
+        "# Generated from site redirects and article legacyPermalink metadata. Do not edit by hand.",
+        "/2021/11/30/what-is-a-meme/ /articles/what-is-a-meme/ 301",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  test("rejects conflicting hand-written and generated redirects", async () => {
+    const root = await testRoot();
+    await writeText(
+      root,
+      "site/content/articles/culture/what-is-a-meme.md",
+      "---\ntitle: What Is A Meme?\nlegacyPermalink: 2021/11/30/what-is-a-meme\n---\n",
+    );
+    await mkdir(path.join(root, "site/content/announcements"), {
+      recursive: true,
+    });
+
+    let message = "";
+
+    try {
+      await generateCloudflareRedirects({
+        outputDir: path.join(root, "dist"),
+        quiet: true,
+        siteRedirects: {
+          "/2021/11/30/what-is-a-meme/": "/articles/other/",
+        },
+        sources: sources(root),
+      });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain(
+      "Conflicting redirect destinations for /2021/11/30/what-is-a-meme/",
     );
   });
 

--- a/tests/scripts/build/verify-build.test.ts
+++ b/tests/scripts/build/verify-build.test.ts
@@ -126,6 +126,8 @@ describe("build verifier", () => {
           catalogLeaks: [],
           draftLeaks: [],
           invalidLegacyRedirects: [],
+          imageAltIssues: [],
+          metadataIssues: [],
           missingArticleJsonLd: [],
           missingLegacyRedirects: [],
           missingRequired: [],

--- a/tests/src/components/articles/ArticleHeader.vitest.ts
+++ b/tests/src/components/articles/ArticleHeader.vitest.ts
@@ -39,6 +39,10 @@ describe("ArticleHeader", () => {
           publicationDateForScholar: "2022/04/06",
           title: "Article Title",
         },
+        semanticDetails: {
+          heading: "Review details",
+          items: [{ label: "Reviewed", value: "Example Book" }],
+        },
         share: {
           actions: [
             {
@@ -85,6 +89,9 @@ describe("ArticleHeader", () => {
     );
     expect(view).toContain("static export of the canonical web article");
     expect(view).toContain("Article description.");
+    expect(view).toContain("data-semantic-details");
+    expect(view).toContain("Review details");
+    expect(view).toContain("Example Book");
     expect(view).not.toContain("Article tags");
   });
 

--- a/tests/src/components/articles/SemanticDetails.vitest.ts
+++ b/tests/src/components/articles/SemanticDetails.vitest.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+
+import SemanticDetails from "../../../../src/components/articles/SemanticDetails.astro";
+import { createAstroTestContainer } from "../../../helpers/astro-container";
+
+describe("SemanticDetails", () => {
+  test("renders compact visible semantic facts", async () => {
+    const container = await createAstroTestContainer();
+    const view = await container.renderToString(SemanticDetails, {
+      props: {
+        details: {
+          description: "Visible context for structured metadata.",
+          heading: "Review details",
+          items: [
+            {
+              href: "https://example.com/book",
+              label: "Reviewed",
+              value: "Example Book",
+            },
+            {
+              label: "Rating",
+              value: "4/5",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(view).toContain("data-semantic-details");
+    expect(view).toContain("Review details");
+    expect(view).toContain("Visible context for structured metadata.");
+    expect(view).toContain("Example Book");
+    expect(view).toContain('href="https://example.com/book"');
+    expect(view).toContain("4/5");
+  });
+
+  test("omits empty semantic detail blocks", async () => {
+    const container = await createAstroTestContainer();
+    const view = await container.renderToString(SemanticDetails, {
+      props: {
+        details: {
+          heading: "Empty details",
+          items: [],
+        },
+      },
+    });
+
+    expect(view).not.toContain("data-semantic-details");
+  });
+});

--- a/tests/src/components/seo/AnnouncementJsonLd.vitest.ts
+++ b/tests/src/components/seo/AnnouncementJsonLd.vitest.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+
+import AnnouncementJsonLd from "../../../../src/components/seo/AnnouncementJsonLd.astro";
+import { createAstroTestContainer } from "../../../helpers/astro-container";
+import { announcementEntry } from "../../../helpers/content";
+
+describe("AnnouncementJsonLd", () => {
+  test("renders article-like JSON-LD for announcements", async () => {
+    const announcement = announcementEntry({
+      data: {
+        author: "The Philosopher's Meme",
+        description: "Announcement description.",
+        tags: ["site news"],
+        title: "Announcement Title",
+        updated: new Date("2026-05-05T00:00:00.000Z"),
+      },
+      id: "announcement-title",
+    });
+    const container = await createAstroTestContainer();
+    const view = await container.renderToString(AnnouncementJsonLd, {
+      props: {
+        announcement,
+        image: {
+          alt: "Announcement image",
+          height: 630,
+          src: "/_astro/social-preview.hash.jpg",
+          type: "image/jpeg",
+          width: 1200,
+        },
+      },
+    });
+
+    expect(view).toContain('"@type":"BlogPosting"');
+    expect(view).toContain('"articleSection":"Announcements"');
+    expect(view).toContain('"dateModified":"2026-05-05T00:00:00.000Z"');
+    expect(view).toContain(
+      '"url":"https://thephilosophersmeme.com/announcements/announcement-title/"',
+    );
+  });
+});

--- a/tests/src/components/seo/AnnouncementJsonLd.vitest.ts
+++ b/tests/src/components/seo/AnnouncementJsonLd.vitest.ts
@@ -37,4 +37,37 @@ describe("AnnouncementJsonLd", () => {
       '"url":"https://thephilosophersmeme.com/announcements/announcement-title/"',
     );
   });
+
+  test("renders semantic event JSON-LD for announcement frontmatter", async () => {
+    const announcement = announcementEntry({
+      data: {
+        author: "The Philosopher's Meme",
+        semantic: {
+          kind: "event",
+          location: {
+            type: "online",
+            url: "https://example.com/live",
+          },
+          name: "Launch Event",
+          startDate: new Date("2026-06-01T19:00:00.000Z"),
+          status: "scheduled",
+        },
+        title: "Launch Announcement",
+      },
+      id: "launch-announcement",
+    });
+    const container = await createAstroTestContainer();
+    const view = await container.renderToString(AnnouncementJsonLd, {
+      props: { announcement },
+    });
+
+    expect(view).toContain('"@graph"');
+    expect(view).toContain('"@type":"BlogPosting"');
+    expect(view).toContain('"@type":"Event"');
+    expect(view).toContain('"name":"Launch Event"');
+    expect(view).toContain('"@type":"VirtualLocation"');
+    expect(view).toContain(
+      '"about":[{"@id":"https://thephilosophersmeme.com/announcements/launch-announcement/#semantic-event"}]',
+    );
+  });
 });

--- a/tests/src/components/seo/ArticleJsonLd.vitest.ts
+++ b/tests/src/components/seo/ArticleJsonLd.vitest.ts
@@ -45,4 +45,44 @@ describe("ArticleJsonLd", () => {
     );
     expect(view).toContain('"url":"https://thephilosophersmeme.com/authors/');
   });
+
+  test("renders semantic profile JSON-LD when article frontmatter opts in", async () => {
+    const article = articleEntry({
+      data: {
+        author: "Seong-Young Her",
+        semantic: {
+          item: {
+            name: "Example Book",
+            type: "book",
+            url: "https://example.com/book",
+          },
+          kind: "review",
+          rating: {
+            best: 5,
+            value: 4,
+          },
+          summary: "Visible review summary.",
+        },
+        title: "Article Title",
+      },
+      id: "article-title",
+    });
+    const container = await createAstroTestContainer();
+    const view = await container.renderToString(ArticleJsonLd, {
+      props: {
+        article,
+        category: categorySummary({ articles: [article] }),
+      },
+    });
+
+    expect(view).toContain('"@graph"');
+    expect(view).toContain('"@type":"BlogPosting"');
+    expect(view).toContain(
+      '"about":[{"@id":"https://thephilosophersmeme.com/articles/article-title/#semantic-review"}]',
+    );
+    expect(view).toContain('"@type":"Review"');
+    expect(view).toContain('"reviewBody":"Visible review summary."');
+    expect(view).toContain('"ratingValue":4');
+    expect(view).toContain('"itemReviewed":{"@type":"Book"');
+  });
 });

--- a/tests/src/components/seo/ArticleScholarMeta.vitest.ts
+++ b/tests/src/components/seo/ArticleScholarMeta.vitest.ts
@@ -9,7 +9,10 @@ describe("ArticleScholarMeta", () => {
     const view = await container.renderToString(ArticleScholarMeta, {
       props: {
         metadata: {
+          abstract: "Article abstract.",
           authors: ["First Author", "Second Author"],
+          keywords: ["memes", "philosophy"],
+          language: "en",
           pdf: {
             articleUrl:
               "https://thephilosophersmeme.com/articles/article-title/",
@@ -24,12 +27,20 @@ describe("ArticleScholarMeta", () => {
           },
           publicationDate: new Date("2022-04-06T23:58:10.000Z"),
           publicationDateForScholar: "2022/04/06",
+          references: ["Author. Source title."],
           title: "Article Title",
         },
       },
     });
 
     expect(view).toContain('name="citation_title" content="Article Title"');
+    expect(view).toContain('name="citation_language" content="en"');
+    expect(view).toContain(
+      'name="citation_abstract" content="Article abstract."',
+    );
+    expect(view).toContain(
+      'name="citation_keywords" content="memes; philosophy"',
+    );
     expect(view).toContain('name="citation_author" content="First Author"');
     expect(view).toContain('name="citation_author" content="Second Author"');
     expect(view).toContain(
@@ -38,6 +49,9 @@ describe("ArticleScholarMeta", () => {
     expect(view).toContain(
       'name="citation_pdf_url" content="https://thephilosophersmeme.com/articles/article-title/article-title.pdf"',
     );
+    expect(view).toContain(
+      'name="citation_reference" content="Author. Source title."',
+    );
   });
 
   test("keeps base Scholar metadata when PDF output is disabled", async () => {
@@ -45,10 +59,14 @@ describe("ArticleScholarMeta", () => {
     const view = await container.renderToString(ArticleScholarMeta, {
       props: {
         metadata: {
+          abstract: "Article abstract.",
           authors: ["First Author"],
+          keywords: [],
+          language: "en",
           pdf: undefined,
           publicationDate: new Date("2022-04-06T23:58:10.000Z"),
           publicationDateForScholar: "2022/04/06",
+          references: [],
           title: "Article Title",
         },
       },
@@ -60,5 +78,7 @@ describe("ArticleScholarMeta", () => {
       'name="citation_publication_date" content="2022/04/06"',
     );
     expect(view).not.toContain("citation_pdf_url");
+    expect(view).not.toContain("citation_keywords");
+    expect(view).not.toContain("citation_reference");
   });
 });

--- a/tests/src/components/seo/PublishableOpenGraphMeta.vitest.ts
+++ b/tests/src/components/seo/PublishableOpenGraphMeta.vitest.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+
+import PublishableOpenGraphMeta from "../../../../src/components/seo/PublishableOpenGraphMeta.astro";
+import { createAstroTestContainer } from "../../../helpers/astro-container";
+
+describe("PublishableOpenGraphMeta", () => {
+  test("renders article Open Graph fields with truthful modified dates only when present", async () => {
+    const container = await createAstroTestContainer();
+    const view = await container.renderToString(PublishableOpenGraphMeta, {
+      props: {
+        author: "Author",
+        publishedAt: new Date("2022-01-01T00:00:00.000Z"),
+        section: "History",
+        tags: ["memes", "history"],
+      },
+    });
+
+    expect(view).toContain(
+      'property="article:published_time" content="2022-01-01T00:00:00.000Z"',
+    );
+    expect(view).toContain('property="article:section" content="History"');
+    expect(view).toContain('property="article:author" content="Author"');
+    expect(view).toContain('property="article:tag" content="memes"');
+    expect(view).not.toContain("article:modified_time");
+  });
+});

--- a/tests/src/components/seo/SiteHead.vitest.ts
+++ b/tests/src/components/seo/SiteHead.vitest.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import SiteHead from "../../../../src/components/seo/SiteHead.astro";
+import { normalizeRouteMetadata } from "../../../../src/lib/metadata";
 import { createAstroTestContainer } from "../../../helpers/astro-container";
 
 describe("SiteHead", () => {
@@ -8,8 +9,6 @@ describe("SiteHead", () => {
     const container = await createAstroTestContainer();
     const view = await container.renderToString(SiteHead, {
       props: {
-        canonicalPath: "/articles/example/",
-        description: "Example description.",
         image: {
           alt: "Example image",
           height: 630,
@@ -17,12 +16,21 @@ describe("SiteHead", () => {
           type: "image/jpeg",
           width: 1200,
         },
-        title: "Example Article",
+        metadata: normalizeRouteMetadata({
+          canonicalPath: "/articles/example/",
+          description: "Example description.",
+          kind: "article",
+          title: "Example Article",
+        }),
         type: "article",
       },
     });
 
     expect(view).toContain("<title>Example Article</title>");
+    expect(view).toContain('name="robots" content="index,follow"');
+    expect(view).toContain('property="og:locale" content="en_US"');
+    expect(view).toContain('name="twitter:site" content="@philo_meme"');
+    expect(view).toContain('name="theme-color" content="#b65a35"');
     expect(view).toContain(
       'href="https://thephilosophersmeme.com/articles/example/"',
     );
@@ -35,5 +43,9 @@ describe("SiteHead", () => {
     expect(view).toContain('property="og:image:height" content="630"');
     expect(view).toContain('property="og:image:type" content="image/jpeg"');
     expect(view).toContain('name="twitter:image:alt" content="Example image"');
+    expect(view).toContain('"@type":"WebSite"');
+    expect(view).toContain(
+      '"@id":"https://thephilosophersmeme.com/#publisher"',
+    );
   });
 });

--- a/tests/src/lib/article-page-view-model.test.ts
+++ b/tests/src/lib/article-page-view-model.test.ts
@@ -41,6 +41,13 @@ describe("articlePageViewModel", () => {
         author: "Known Author",
         description: "Current article description.",
         image: articleImage,
+        semantic: {
+          item: {
+            name: "Example Book",
+            type: "book",
+          },
+          kind: "review",
+        },
         tags: ["memes"],
         title: "Current Article",
       },
@@ -117,6 +124,13 @@ describe("articlePageViewModel", () => {
       label: "View Site Bibliography",
     });
     expect(page.searchable).toBe(true);
+    expect(page.semanticDetails).toMatchObject({
+      heading: "Review details",
+      items: [
+        { label: "Reviewed", value: "Example Book" },
+        { label: "Type", value: "Book" },
+      ],
+    });
     expect(page.tagsVisible).toBe(true);
     expect(page.profileLinksEnabled).toBe(true);
     expect(page.support.enabled).toBe(true);

--- a/tests/src/lib/article-pdf.test.ts
+++ b/tests/src/lib/article-pdf.test.ts
@@ -30,6 +30,8 @@ describe("article PDF helpers", () => {
     const article = articleEntry({
       data: {
         author: "Legacy Author",
+        description: "A cluster definition.",
+        tags: ["memes", "definition"],
         title: "What Is A Meme?",
       },
       date: new Date("2021-11-30T23:58:10.000Z"),
@@ -50,7 +52,10 @@ describe("article PDF helpers", () => {
         site: "https://thephilosophersmeme.com",
       }),
     ).toEqual({
+      abstract: "A cluster definition.",
       authors: ["Claudia Vulliamy"],
+      keywords: ["memes", "definition"],
+      language: "en",
       pdf: {
         articleUrl: "https://thephilosophersmeme.com/articles/what-is-a-meme/",
         authors: ["Claudia Vulliamy"],
@@ -64,8 +69,48 @@ describe("article PDF helpers", () => {
       },
       publicationDate: new Date("2021-11-30T23:58:10.000Z"),
       publicationDateForScholar: "2021/11/30",
+      references: [],
       title: "What Is A Meme?",
     });
+  });
+
+  test("derives deterministic citation_reference values from article references", () => {
+    const article = articleEntry({ id: "cited-article" });
+
+    expect(
+      articleScholarMetaViewModel({
+        article,
+        articleReferences: {
+          citations: [
+            {
+              bibtex: {
+                entryType: "article",
+                fields: {},
+                key: "source",
+                normalizedKey: "source",
+                raw: "@article{source}",
+              },
+              definition: {
+                children: [
+                  {
+                    children: [],
+                    kind: "paragraph",
+                    text: "Author. Source title.",
+                  },
+                ],
+              },
+              displayLabel: "1",
+              id: "cite-source",
+              kind: "citation",
+              label: "cite-source",
+              order: 1,
+              references: [],
+            },
+          ],
+          notes: [],
+        },
+      }).references,
+    ).toEqual(["Author. Source title."]);
   });
 
   test("falls back to the legacy byline when structured authors are unavailable", () => {

--- a/tests/src/lib/content-schemas.test.ts
+++ b/tests/src/lib/content-schemas.test.ts
@@ -42,11 +42,13 @@ describe("content schemas", () => {
       image: { format: "jpg", height: 640, src: "/article.jpg", width: 960 },
       tags: ["meme history", "c++"],
       title: "Article Title",
+      updated: "2022-05-01",
     });
 
     expect(parsed.success).toBe(true);
     if (parsed.success) {
       expect("pdf" in parsed.data && parsed.data.pdf).toBe(true);
+      expect(parsed.data.updated).toEqual(new Date("2022-05-01"));
     }
     expect(
       schema.safeParse({

--- a/tests/src/lib/content-schemas.test.ts
+++ b/tests/src/lib/content-schemas.test.ts
@@ -40,6 +40,17 @@ describe("content schemas", () => {
       date: "2022-04-06",
       description: "Description",
       image: { format: "jpg", height: 640, src: "/article.jpg", width: 960 },
+      semantic: {
+        item: {
+          name: "Example Book",
+          type: "book",
+        },
+        kind: "review",
+        rating: {
+          best: 5,
+          value: 4,
+        },
+      },
       tags: ["meme history", "c++"],
       title: "Article Title",
       updated: "2022-05-01",
@@ -100,6 +111,35 @@ describe("content schemas", () => {
         date: "2022-04-06",
         description: "Description",
         tags: ["/pol/"],
+        title: "Article Title",
+      }).success,
+    ).toBe(false);
+    expect(
+      schema.safeParse({
+        author: "Author",
+        date: "2022-04-06",
+        description: "Description",
+        semantic: {
+          item: {
+            name: "Example Book",
+            type: "not-supported",
+          },
+          kind: "review",
+        },
+        title: "Article Title",
+      }).success,
+    ).toBe(false);
+    expect(
+      schema.safeParse({
+        author: "Author",
+        date: "2022-04-06",
+        description: "Description",
+        semantic: {
+          endDate: "2026-05-01",
+          kind: "event",
+          name: "Backwards Event",
+          startDate: "2026-05-02",
+        },
         title: "Article Title",
       }).success,
     ).toBe(false);

--- a/tests/src/lib/metadata.test.ts
+++ b/tests/src/lib/metadata.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  breadcrumbEntityId,
+  breadcrumbListJsonLd,
+  itemListEntityId,
+  itemListJsonLd,
+  jsonLdGraph,
+  normalizeRouteMetadata,
+  publishableDiscoveryPolicy,
+  publisherEntityId,
+  routeDiscoveryPolicy,
+  routeEntityId,
+  routeRobotsPolicy,
+  siteIdentityJsonLd,
+  sitemapIncludesPath,
+  siteRootUrl,
+  webPageEntityId,
+  webPageJsonLd,
+  websiteEntityId,
+} from "../../../src/lib/metadata";
+
+describe("metadata contract", () => {
+  test("normalizes indexable public route metadata", () => {
+    expect(
+      normalizeRouteMetadata({
+        canonicalPath: "/articles/",
+        description: "Browse articles.",
+        kind: "articles-index",
+        title: "Articles",
+      }),
+    ).toEqual({
+      canonicalPath: "/articles/",
+      description: "Browse articles.",
+      discovery: {
+        contentIndex: true,
+        feed: false,
+        sitemap: true,
+      },
+      kind: "articles-index",
+      robots: "index,follow",
+      title: "Articles",
+    });
+  });
+
+  test("keeps utility routes out of indexable discovery surfaces", () => {
+    expect(routeRobotsPolicy("search")).toBe("noindex,follow");
+    expect(routeRobotsPolicy("not-found")).toBe("noindex,follow");
+    expect(routeRobotsPolicy("catalog")).toBe("noindex,follow");
+    expect(routeDiscoveryPolicy("search")).toEqual({
+      contentIndex: false,
+      feed: false,
+      sitemap: false,
+    });
+  });
+
+  test("maps article-like visibility to sitemap, feed, and content index policy", () => {
+    expect(
+      publishableDiscoveryPolicy({
+        directory: true,
+        feed: false,
+        search: true,
+      }),
+    ).toEqual({
+      contentIndex: true,
+      feed: false,
+      sitemap: true,
+    });
+  });
+
+  test("excludes known noindex routes from sitemap paths", () => {
+    expect(sitemapIncludesPath("/articles/")).toBe(true);
+    expect(sitemapIncludesPath("/search/")).toBe(false);
+    expect(sitemapIncludesPath("/search/index.html")).toBe(false);
+    expect(sitemapIncludesPath("/404/")).toBe(false);
+    expect(sitemapIncludesPath("/catalog/buttons/")).toBe(false);
+  });
+
+  test("builds stable site and route entity IDs", () => {
+    const site = "https://example.com";
+
+    expect(siteRootUrl(site)).toBe("https://example.com/");
+    expect(websiteEntityId(site)).toBe("https://example.com/#website");
+    expect(publisherEntityId(site)).toBe("https://example.com/#publisher");
+    expect(routeEntityId("/articles/post/", "article", site)).toBe(
+      "https://example.com/articles/post/#article",
+    );
+    expect(webPageEntityId("/articles/post/", site)).toBe(
+      "https://example.com/articles/post/#webpage",
+    );
+    expect(itemListEntityId("/articles/", site)).toBe(
+      "https://example.com/articles/#itemlist",
+    );
+    expect(breadcrumbEntityId("/articles/post/", site)).toBe(
+      "https://example.com/articles/post/#breadcrumb",
+    );
+  });
+
+  test("builds site identity and route webpage JSON-LD graph nodes", () => {
+    const site = "https://example.com";
+    const metadata = normalizeRouteMetadata({
+      canonicalPath: "/articles/",
+      description: "Browse articles.",
+      kind: "articles-index",
+      title: "Articles",
+    });
+
+    const graph = jsonLdGraph([
+      ...siteIdentityJsonLd(site),
+      webPageJsonLd(metadata, site),
+    ]);
+    if (graph === undefined) {
+      throw new Error("Expected metadata graph");
+    }
+    const nodes = graph["@graph"];
+
+    expect(graph["@context"]).toBe("https://schema.org");
+    expect(Array.isArray(nodes)).toBe(true);
+    expect(nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          "@id": "https://example.com/#publisher",
+          "@type": "Organization",
+          name: "The Philosopher's Meme",
+        }),
+        expect.objectContaining({
+          "@id": "https://example.com/#website",
+          "@type": "WebSite",
+        }),
+        expect.objectContaining({
+          "@id": "https://example.com/articles/#webpage",
+          "@type": "CollectionPage",
+          isPartOf: { "@id": "https://example.com/#website" },
+          name: "Articles",
+        }),
+      ]),
+    );
+  });
+
+  test("builds item lists and breadcrumb lists from visible route items", () => {
+    const site = "https://example.com";
+
+    expect(
+      itemListJsonLd(
+        "/articles/",
+        [
+          {
+            description: "First article.",
+            href: "/articles/one/",
+            title: "One",
+          },
+        ],
+        site,
+      ),
+    ).toEqual({
+      "@id": "https://example.com/articles/#itemlist",
+      "@type": "ItemList",
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          description: "First article.",
+          name: "One",
+          position: 1,
+          url: "https://example.com/articles/one/",
+        },
+      ],
+      numberOfItems: 1,
+    });
+
+    expect(
+      breadcrumbListJsonLd(
+        "/articles/one/",
+        [
+          { href: "/", title: "Home" },
+          { href: "/articles/", title: "Articles" },
+          { href: "/articles/one/", title: "One" },
+        ],
+        site,
+      ),
+    ).toEqual({
+      "@id": "https://example.com/articles/one/#breadcrumb",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          item: "https://example.com/",
+          name: "Home",
+          position: 1,
+        },
+        {
+          "@type": "ListItem",
+          item: "https://example.com/articles/",
+          name: "Articles",
+          position: 2,
+        },
+        {
+          "@type": "ListItem",
+          item: "https://example.com/articles/one/",
+          name: "One",
+          position: 3,
+        },
+      ],
+    });
+  });
+});

--- a/tests/src/lib/semantic-metadata.test.ts
+++ b/tests/src/lib/semantic-metadata.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  semanticDetailsViewModel,
+  semanticMetadataJsonLd,
+  semanticMetadataSchema,
+} from "../../../src/lib/semantic-metadata";
+
+describe("semantic metadata", () => {
+  test("validates supported semantic profile kinds", () => {
+    expect(
+      semanticMetadataSchema.safeParse({
+        item: {
+          author: "Example Author",
+          name: "Example Book",
+          type: "book",
+          url: "https://example.com/book",
+        },
+        kind: "review",
+        rating: {
+          best: 5,
+          value: 4,
+        },
+        summary: "A visible review summary.",
+      }).success,
+    ).toBe(true);
+    expect(
+      semanticMetadataSchema.safeParse({
+        kind: "faq",
+        items: [
+          {
+            answer: "Because it is visible on the page.",
+            question: "Why use FAQ metadata?",
+          },
+        ],
+      }).success,
+    ).toBe(true);
+    expect(
+      semanticMetadataSchema.safeParse({
+        kind: "event",
+        name: "Broken Event",
+      }).success,
+    ).toBe(false);
+  });
+
+  test("builds visible semantic details without empty facts", () => {
+    const details = semanticDetailsViewModel({
+      item: {
+        author: ["Example Author", "Second Author"],
+        name: "Example Book",
+        type: "book",
+      },
+      kind: "review",
+      rating: {
+        best: 5,
+        value: 4,
+      },
+      summary: "A visible review summary.",
+    });
+
+    expect(details).toMatchObject({
+      description: "A visible review summary.",
+      heading: "Review details",
+      items: [
+        { label: "Reviewed", value: "Example Book" },
+        { label: "Type", value: "Book" },
+        { label: "Author", value: "Example Author, Second Author" },
+        { label: "Rating", value: "4/5" },
+      ],
+    });
+  });
+
+  test("builds semantic JSON-LD nodes and article references", () => {
+    const result = semanticMetadataJsonLd(
+      {
+        description: "A release event.",
+        kind: "event",
+        location: {
+          type: "online",
+          url: "https://example.com/live",
+        },
+        name: "Launch Event",
+        startDate: new Date("2026-06-01T19:00:00.000Z"),
+        status: "scheduled",
+      },
+      {
+        authorName: "Author",
+        canonicalPath: "/articles/launch-event/",
+        datePublished: new Date("2026-05-01T00:00:00.000Z"),
+        site: "https://example.com",
+      },
+    );
+
+    expect(result.references).toEqual([
+      {
+        "@id": "https://example.com/articles/launch-event/#semantic-event",
+      },
+    ]);
+    expect(result.nodes[0]).toMatchObject({
+      "@id": "https://example.com/articles/launch-event/#semantic-event",
+      "@type": "Event",
+      description: "A release event.",
+      location: {
+        "@type": "VirtualLocation",
+        url: "https://example.com/live",
+      },
+      name: "Launch Event",
+      startDate: "2026-06-01T19:00:00.000Z",
+    });
+  });
+});

--- a/tests/src/lib/seo.test.ts
+++ b/tests/src/lib/seo.test.ts
@@ -35,12 +35,32 @@ describe("SEO helpers", () => {
   });
 
   test("omits image and category metadata when unavailable", () => {
-    expect(
-      articleBlogPostingJsonLd(article(), undefined, undefined),
-    ).toMatchObject({
-      articleSection: undefined,
-      image: undefined,
+    const jsonLd = articleBlogPostingJsonLd(article(), undefined, undefined);
+
+    expect(jsonLd).toMatchObject({
+      "@id": "https://thephilosophersmeme.com/articles/title/#article",
+      inLanguage: "en",
+      isPartOf: { "@id": "https://thephilosophersmeme.com/#website" },
+      mainEntityOfPage: {
+        "@id": "https://thephilosophersmeme.com/articles/title/#webpage",
+      },
+      publisher: { "@id": "https://thephilosophersmeme.com/#publisher" },
       url: "https://thephilosophersmeme.com/articles/title/",
+    });
+    expect("articleSection" in jsonLd).toBe(false);
+    expect("dateModified" in jsonLd).toBe(false);
+    expect("image" in jsonLd).toBe(false);
+  });
+
+  test("emits modified dates only when article frontmatter provides them", () => {
+    expect(
+      articleBlogPostingJsonLd(
+        article({ updated: new Date("2022-02-01T00:00:00Z") }),
+        undefined,
+        "https://example.com",
+      ),
+    ).toMatchObject({
+      dateModified: "2022-02-01T00:00:00.000Z",
     });
   });
 

--- a/tests/src/lib/site-config.test.ts
+++ b/tests/src/lib/site-config.test.ts
@@ -59,6 +59,11 @@ describe("site config", () => {
   test("loads the current TPM site config from the site directory", () => {
     expect(siteConfig.identity.title).toBe("The Philosopher's Meme");
     expect(siteConfig.identity.url).toBe("https://thephilosophersmeme.com");
+    expect(siteConfig.identity.locale).toBe("en_US");
+    expect(siteConfig.identity.publisherType).toBe("organization");
+    expect(siteConfig.identity.logo).toBe("/favicon.svg?v=2");
+    expect(siteConfig.identity.themeColor).toBe("#b65a35");
+    expect(siteConfig.identity.sameAs).toContain("https://x.com/philo_meme");
     expect(siteConfig.navigation.primary).toEqual([
       { href: "/articles/", label: "Articles" },
       { href: "/about/", label: "About" },
@@ -107,6 +112,9 @@ describe("site config", () => {
     const parsed: SiteConfig = parseSiteConfig(validConfig);
 
     expect(parsed.identity.title).toBe("Example Blog");
+    expect(parsed.identity.locale).toBe("en_US");
+    expect(parsed.identity.publisherType).toBe("organization");
+    expect(parsed.identity.sameAs).toEqual([]);
     expect(parsed.share).toEqual({ targets: Array.from(siteShareTargetIds) });
     expect(parsed.features.search).toBe(true);
     expect(parsed.homepage.discoveryLinks).toEqual([


### PR DESCRIPTION
Make improvements to machine readability, across the site. This will help with SEO, accessibility, and long term caching.

Also added frontmatter support for various metadata tags such as reviews and videos so authors can optionally specify additional metadata in the frontmatter that will be added as meta tags in articles.