### PR TITLE
milestone 13

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,10 +91,10 @@ the correct boundary.
 - `apps/studio/`: static Astro frontend shell and minimal Tauri desktop shell
   for the future studio. Keep it read-only until operation-backed Tauri
   bindings, plan/apply safety, and provider capabilities are implemented.
-- `crates/tpm-mcp/`: transport-agnostic read-only MCP resource and safety
-  contracts over shared operation results. Do not add source writes or provider
-  mutations here before plan/apply, permission, audit, and capability gates
-  exist.
+- `crates/tpm-mcp/`: transport-agnostic MCP resource, tool, plan, apply-gate,
+  and safety contracts over shared operation results. Do not add source writes
+  or provider mutations here before plan/apply, permission, audit, and
+  capability gates exist.
 - `site/`: default TPM site instance. Publication-specific content, assets,
   public files, theme overrides, redirects, and site config belong here.
 - `site/config/site.json`: publication configuration. Keep TPM-specific text,
@@ -210,9 +210,9 @@ the correct boundary.
   safety, workspace discovery, and product-contract design.
 - `docs/STUDIO_MCP_SAFETY_MODEL.md`: MCP resource/tool, permission,
   plan/apply, redaction, and agent safety model.
-- `docs/STUDIO_MCP_RESOURCE_CONTRACTS.md`: implemented read-only MCP resource
-  catalog, permission defaults, redaction summary, unsupported capability
-  behavior, and Milestone 13 handoff notes.
+- `docs/STUDIO_MCP_RESOURCE_CONTRACTS.md`: implemented MCP resource/tool
+  catalog, permission defaults, plan/apply gates, redaction summary,
+  unsupported capability behavior, and Milestone 13 handoff notes.
 - `docs/STUDIO_PRODUCT_TEST_PLAN.md`: mocked-provider product test matrix for
   studio workflows, accessibility, recovery, security, and provider failures.
 - `docs/STUDIO_PARITY_FIXTURE_STRATEGY.md`: GUI/CLI/MCP/CI parity fixture

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -308,6 +308,64 @@ Remaining blocker notes:
 - [x] Run appropriate final checks and summarize completed work plus remaining
       blockers.
 
+### Milestone 13.5: Re-open Remaining MCP Work After Milestone 12
+
+- [x] Re-read `IRK-200`, `IRK-202`, `IRK-203`, MCP safety/resource docs,
+      Studio authoring operations, adapter runtime docs, Rust operation
+      contracts, and Rust engineering guide.
+- [x] Confirm the remaining work can consume existing operation payloads
+      without creating an MCP-only source, preview, publish, credential, or
+      mutation model.
+- [x] Record the implementation shape for release/preview reports,
+      plan/apply gates, parity tests, docs, and Linear handoff.
+
+### IRK-200: MCP Release-Plan And Preview-Report Tools
+
+- [x] Design the MCP release/preview report slice around existing
+      `studio.preview.plan`, `studio.release.plan`, `studio.publish.apply`,
+      and workflow verification operations.
+- [x] Add read/report MCP resources for preview reports, release plans,
+      publish plans, and workflow verification.
+- [x] Add read/report MCP tools that wrap those resources with stable
+      diagnostics, permission requirements, redaction summaries, and audit
+      events.
+- [x] Add focused tests for catalog order, operation wrapping, permission
+      denial, provider-capability diagnostics, and redaction behavior.
+- [x] Update MCP docs and verify focused Rust checks before updating Linear.
+
+### IRK-202: Gated MCP Plan/Apply Contracts
+
+- [x] Design the plan/apply MCP surface so plans can be inspected now while
+      applies remain impossible without explicit scopes, approval data, and
+      implemented mutation operations.
+- [x] Add explicit MCP permission scopes for source proposals/writes, media
+      writes, preview/build, workflow transitions, deploy publish/rollback,
+      credential tests, extensions, and admin-level actions.
+- [x] Add plan tools for source edits, settings changes, media changes, and
+      publish operations over shared Studio operation results.
+- [x] Add apply-gate tools that reject unsafe or unsupported applies with
+      diagnostics instead of mutating source files, providers, credentials, or
+      generated output.
+- [x] Add focused tests for denied applies, missing scopes, unsupported apply
+      operations, audit events, and zero-mutation guarantees.
+- [x] Update MCP safety docs and verify focused Rust checks before updating
+      Linear.
+
+### IRK-203: MCP Parity And Safety Verification
+
+- [x] Add parity tests proving MCP read/report/plan responses preserve shared
+      operation IDs, `interface: "mcp"`, diagnostics, payloads, redaction, and
+      audit shape.
+- [x] Add safety tests covering read-only defaults, plan-only behavior,
+      denied writes, unsupported applies, missing capabilities, and redaction.
+- [x] Add or update safe MCP usage documentation for current defaults,
+      implemented tools/resources, non-goals, and future transport/server
+      handoff.
+- [x] Run focused MCP/Rust checks plus accountability/release-relevant checks
+      and fix any issues.
+- [x] Attach relevant docs to Milestone 13 Linear issues, move remaining
+      issues and parent to In Review, and summarize handoff.
+
 ## Active Milestone 10: Adapter Contracts And Provider Capability Runtime
 
 This pass implements provider-neutral adapter contracts and capability

--- a/crates/tpm-mcp/src/lib.rs
+++ b/crates/tpm-mcp/src/lib.rs
@@ -13,7 +13,9 @@ use tpm_core::Severity;
 use tpm_diagnostics::{Diagnostic, DiagnosticCode, DiagnosticReport};
 use tpm_operations::{
     OperationInterface, OperationResult, run_image_asset_verification, run_redirect_report,
-    run_release_inspect, run_site_doctor, run_workspace_status,
+    run_release_inspect, run_site_doctor, run_studio_content_editor, run_studio_media_library,
+    run_studio_preview_plan, run_studio_publish_apply, run_studio_release_plan,
+    run_studio_settings_inspect, run_studio_workflow_verify, run_workspace_status,
 };
 
 /// Current schema version for serialized MCP resource responses.
@@ -48,6 +50,20 @@ pub enum ResourceKind {
     RoutesRedirects,
     /// Site workspace diagnostics.
     SiteDiagnostics,
+    /// Studio content and source-edit plan report.
+    StudioContentPlan,
+    /// Studio media materialization/change plan report.
+    StudioMediaPlan,
+    /// Studio preview report over shared operation data.
+    StudioPreviewReport,
+    /// Studio publish plan and apply-gate report.
+    StudioPublishPlan,
+    /// Studio release manifest and health report.
+    StudioReleasePlan,
+    /// Studio settings change plan report.
+    StudioSettingsPlan,
+    /// Studio authoring/publish workflow verification report.
+    StudioWorkflowVerify,
     /// Workspace source-root and source-inventory status.
     WorkspaceStatus,
 }
@@ -64,6 +80,25 @@ impl ResourceKind {
             Self::ReleaseInspect => ResourceUri::from_static("tpm://resources/release/inspect"),
             Self::RoutesRedirects => ResourceUri::from_static("tpm://resources/routes/redirects"),
             Self::SiteDiagnostics => ResourceUri::from_static("tpm://resources/site/diagnostics"),
+            Self::StudioContentPlan => {
+                ResourceUri::from_static("tpm://resources/studio/content-plan")
+            }
+            Self::StudioMediaPlan => ResourceUri::from_static("tpm://resources/studio/media-plan"),
+            Self::StudioPreviewReport => {
+                ResourceUri::from_static("tpm://resources/studio/preview-report")
+            }
+            Self::StudioPublishPlan => {
+                ResourceUri::from_static("tpm://resources/studio/publish-plan")
+            }
+            Self::StudioReleasePlan => {
+                ResourceUri::from_static("tpm://resources/studio/release-plan")
+            }
+            Self::StudioSettingsPlan => {
+                ResourceUri::from_static("tpm://resources/studio/settings-plan")
+            }
+            Self::StudioWorkflowVerify => {
+                ResourceUri::from_static("tpm://resources/studio/workflow-verify")
+            }
             Self::WorkspaceStatus => ResourceUri::from_static("tpm://resources/workspace/status"),
         }
     }
@@ -77,6 +112,13 @@ impl ResourceKind {
             Self::ReleaseInspect => "Release inspection",
             Self::RoutesRedirects => "Route redirects",
             Self::SiteDiagnostics => "Site diagnostics",
+            Self::StudioContentPlan => "Studio content plan",
+            Self::StudioMediaPlan => "Studio media plan",
+            Self::StudioPreviewReport => "Studio preview report",
+            Self::StudioPublishPlan => "Studio publish plan",
+            Self::StudioReleasePlan => "Studio release plan",
+            Self::StudioSettingsPlan => "Studio settings plan",
+            Self::StudioWorkflowVerify => "Studio workflow verification",
             Self::WorkspaceStatus => "Workspace status",
         }
     }
@@ -92,6 +134,13 @@ impl ResourceKind {
             Self::ReleaseInspect => "Wraps the read-only generated-output release inspection.",
             Self::RoutesRedirects => "Wraps the read-only route and redirect report.",
             Self::SiteDiagnostics => "Wraps the read-only site doctor diagnostic operation.",
+            Self::StudioContentPlan => "Wraps the Studio content editor source plan.",
+            Self::StudioMediaPlan => "Wraps the Studio media materialization plan.",
+            Self::StudioPreviewReport => "Wraps the Studio preview plan and parity report.",
+            Self::StudioPublishPlan => "Wraps the Studio publish apply gate as a plan report.",
+            Self::StudioReleasePlan => "Wraps the Studio release manifest and health report.",
+            Self::StudioSettingsPlan => "Wraps the Studio settings inspection and change plan.",
+            Self::StudioWorkflowVerify => "Wraps the Studio workflow verification report.",
             Self::WorkspaceStatus => "Wraps the read-only workspace status operation.",
         }
     }
@@ -110,14 +159,60 @@ impl ResourceKind {
             Self::SiteDiagnostics => {
                 vec![PermissionScope::Inspect, PermissionScope::DiagnosticsRead]
             }
+            Self::StudioContentPlan | Self::StudioSettingsPlan => vec![
+                PermissionScope::Inspect,
+                PermissionScope::SourceRead,
+                PermissionScope::SourcePropose,
+            ],
+            Self::StudioMediaPlan => {
+                vec![PermissionScope::Inspect, PermissionScope::MediaRead]
+            }
+            Self::StudioPreviewReport => {
+                vec![PermissionScope::Inspect, PermissionScope::PreviewRun]
+            }
+            Self::StudioPublishPlan | Self::StudioReleasePlan => vec![
+                PermissionScope::Inspect,
+                PermissionScope::ReleaseRead,
+                PermissionScope::ProviderStatusRead,
+            ],
+            Self::StudioWorkflowVerify => vec![
+                PermissionScope::Inspect,
+                PermissionScope::DiagnosticsRead,
+                PermissionScope::ProviderStatusRead,
+            ],
             Self::WorkspaceStatus => vec![PermissionScope::Inspect, PermissionScope::SourceRead],
         }
     }
 
-    const fn all() -> [Self; 6] {
+    const fn safety_class(self) -> ResourceSafetyClass {
+        match self {
+            Self::AdapterCapabilities
+            | Self::MediaImages
+            | Self::ReleaseInspect
+            | Self::RoutesRedirects
+            | Self::SiteDiagnostics
+            | Self::WorkspaceStatus => ResourceSafetyClass::ReadOnly,
+            Self::StudioContentPlan
+            | Self::StudioMediaPlan
+            | Self::StudioPreviewReport
+            | Self::StudioPublishPlan
+            | Self::StudioReleasePlan
+            | Self::StudioSettingsPlan
+            | Self::StudioWorkflowVerify => ResourceSafetyClass::PlanOnly,
+        }
+    }
+
+    const fn all() -> [Self; 13] {
         [
             Self::WorkspaceStatus,
             Self::SiteDiagnostics,
+            Self::StudioSettingsPlan,
+            Self::StudioContentPlan,
+            Self::StudioMediaPlan,
+            Self::StudioPreviewReport,
+            Self::StudioReleasePlan,
+            Self::StudioPublishPlan,
+            Self::StudioWorkflowVerify,
             Self::ReleaseInspect,
             Self::MediaImages,
             Self::RoutesRedirects,
@@ -143,6 +238,34 @@ impl ResourceKind {
             Self::SiteDiagnostics => {
                 ResourceOperation::Operation(run_site_doctor(workspace, OperationInterface::Mcp))
             }
+            Self::StudioContentPlan => ResourceOperation::Operation(run_studio_content_editor(
+                workspace,
+                OperationInterface::Mcp,
+            )),
+            Self::StudioMediaPlan => ResourceOperation::Operation(run_studio_media_library(
+                workspace,
+                OperationInterface::Mcp,
+            )),
+            Self::StudioPreviewReport => ResourceOperation::Operation(run_studio_preview_plan(
+                workspace,
+                OperationInterface::Mcp,
+            )),
+            Self::StudioPublishPlan => ResourceOperation::Operation(run_studio_publish_apply(
+                workspace,
+                OperationInterface::Mcp,
+            )),
+            Self::StudioReleasePlan => ResourceOperation::Operation(run_studio_release_plan(
+                workspace,
+                OperationInterface::Mcp,
+            )),
+            Self::StudioSettingsPlan => ResourceOperation::Operation(run_studio_settings_inspect(
+                workspace,
+                OperationInterface::Mcp,
+            )),
+            Self::StudioWorkflowVerify => ResourceOperation::Operation(run_studio_workflow_verify(
+                workspace,
+                OperationInterface::Mcp,
+            )),
             Self::WorkspaceStatus => ResourceOperation::Operation(run_workspace_status(
                 workspace,
                 OperationInterface::Mcp,
@@ -173,20 +296,44 @@ impl ResourceUri {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum PermissionScope {
+    /// Administrative access to extension or server-level configuration.
+    Admin,
+    /// Run build/report planning.
+    BuildRun,
+    /// Test credential references without exposing secret values.
+    CredentialTest,
+    /// Run preview or preview-report planning.
+    DeployPreview,
+    /// Publish deploy output.
+    DeployPublish,
+    /// Roll back a deploy or published artifact.
+    DeployRollback,
     /// Read current diagnostics.
     DiagnosticsRead,
+    /// Configure extensions.
+    ExtensionConfigure,
     /// Inspect read-only platform state.
     Inspect,
     /// Read media reports.
     MediaRead,
+    /// Write media or materialized media references.
+    MediaWrite,
     /// Read provider status and capabilities.
     ProviderStatusRead,
+    /// Run preview or preview-report planning.
+    PreviewRun,
     /// Read release and generated-output reports.
     ReleaseRead,
     /// Read route and redirect reports.
     RoutesRead,
+    /// Propose source changes without applying them.
+    SourcePropose,
     /// Read source/workspace summaries.
     SourceRead,
+    /// Write source files through an approved plan/apply operation.
+    SourceWrite,
+    /// Transition editorial or publishing workflow state.
+    WorkflowTransition,
 }
 
 /// Permission set granted to an MCP request.
@@ -212,9 +359,11 @@ impl PermissionSet {
             PermissionScope::DiagnosticsRead,
             PermissionScope::Inspect,
             PermissionScope::MediaRead,
+            PermissionScope::PreviewRun,
             PermissionScope::ProviderStatusRead,
             PermissionScope::ReleaseRead,
             PermissionScope::RoutesRead,
+            PermissionScope::SourcePropose,
             PermissionScope::SourceRead,
         ])
     }
@@ -243,6 +392,8 @@ impl PermissionSet {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ResourceSafetyClass {
+    /// The resource exposes a dry-run or plan report but performs no writes.
+    PlanOnly,
     /// The resource performs no source, provider, credential, or output writes.
     ReadOnly,
 }
@@ -271,7 +422,7 @@ impl ResourceDescriptor {
             description: kind.description().to_owned(),
             mime_type: "application/json".to_owned(),
             required_scopes: kind.required_scopes(),
-            safety_class: ResourceSafetyClass::ReadOnly,
+            safety_class: kind.safety_class(),
         }
     }
 
@@ -439,8 +590,31 @@ impl From<ToolStatus> for AuditOutcome {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum AuditSafetyClass {
+    /// The request targeted an apply gate but did not perform a mutation.
+    ApplyGate,
+    /// The request produced or inspected a dry-run plan without applying it.
+    PlanOnly,
     /// The request performed no source, provider, credential, or output writes.
     ReadOnly,
+}
+
+impl From<ResourceSafetyClass> for AuditSafetyClass {
+    fn from(value: ResourceSafetyClass) -> Self {
+        match value {
+            ResourceSafetyClass::PlanOnly => Self::PlanOnly,
+            ResourceSafetyClass::ReadOnly => Self::ReadOnly,
+        }
+    }
+}
+
+impl From<ToolSafetyClass> for AuditSafetyClass {
+    fn from(value: ToolSafetyClass) -> Self {
+        match value {
+            ToolSafetyClass::ApplyGate => Self::ApplyGate,
+            ToolSafetyClass::PlanOnly => Self::PlanOnly,
+            ToolSafetyClass::ReadOnly => Self::ReadOnly,
+        }
+    }
 }
 
 /// Credential access recorded in MCP audit events.
@@ -449,6 +623,8 @@ pub enum AuditSafetyClass {
 pub enum AuditCredentialAccess {
     /// The request did not access credential references or secret values.
     None,
+    /// The request may expose non-secret credential references, never values.
+    ReferenceOnly,
 }
 
 /// Mutation class recorded in MCP audit events.
@@ -457,6 +633,10 @@ pub enum AuditCredentialAccess {
 pub enum AuditMutation {
     /// The request did not mutate source, providers, credentials, or output.
     None,
+    /// The request generated or inspected a plan but did not apply it.
+    Planned,
+    /// The request targeted a mutation gate and was rejected before mutation.
+    Rejected,
 }
 
 /// Deterministic MCP audit event for the current read-only safety envelope.
@@ -573,14 +753,36 @@ pub fn read_resource(request: ResourceRequest) -> ResourceResponse {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ToolKind {
+    /// Reject an unsafe media apply request unless the future apply engine exists.
+    ApplyMediaChange,
+    /// Reject an unsafe publish apply request unless the future apply engine exists.
+    ApplyPublish,
+    /// Reject an unsafe settings apply request unless the future apply engine exists.
+    ApplySettingsChange,
+    /// Reject an unsafe source apply request unless the future apply engine exists.
+    ApplySourceEdit,
     /// Inspect adapter capability availability.
     AdapterCapabilities,
     /// Inspect current site diagnostics.
     Diagnostics,
+    /// Inspect a media materialization/change plan without mutating source.
+    MediaChangePlan,
+    /// Inspect a provider-neutral publish plan without applying it.
+    PublishPlan,
+    /// Inspect a Studio preview report without generating new output.
+    PreviewReport,
+    /// Inspect a Studio release manifest and health report.
+    ReleasePlan,
     /// List available read-only MCP resources.
     ResourceCatalog,
+    /// Inspect a settings change plan without mutating source.
+    SettingsChangePlan,
     /// Inspect workspace status.
     SiteStatus,
+    /// Inspect a source edit plan without mutating source.
+    SourceEditPlan,
+    /// Inspect Studio workflow verification status.
+    WorkflowVerify,
 }
 
 impl ToolKind {
@@ -588,10 +790,21 @@ impl ToolKind {
     #[must_use]
     pub const fn name(self) -> &'static str {
         match self {
+            Self::ApplyMediaChange => "apply_media_change",
+            Self::ApplyPublish => "apply_publish",
+            Self::ApplySettingsChange => "apply_settings_change",
+            Self::ApplySourceEdit => "apply_source_edit",
             Self::AdapterCapabilities => "adapter_capabilities",
             Self::Diagnostics => "site_diagnostics",
+            Self::MediaChangePlan => "media_change_plan",
+            Self::PublishPlan => "publish_plan",
+            Self::PreviewReport => "preview_report",
+            Self::ReleasePlan => "release_plan",
             Self::ResourceCatalog => "resource_catalog",
+            Self::SettingsChangePlan => "settings_change_plan",
             Self::SiteStatus => "site_status",
+            Self::SourceEditPlan => "source_edit_plan",
+            Self::WorkflowVerify => "workflow_verify",
         }
     }
 
@@ -599,30 +812,92 @@ impl ToolKind {
     #[must_use]
     pub const fn description(self) -> &'static str {
         match self {
+            Self::ApplyMediaChange => {
+                "Apply an approved media change plan when mutation support exists."
+            }
+            Self::ApplyPublish => {
+                "Apply an approved publish plan when provider mutation support exists."
+            }
+            Self::ApplySettingsChange => {
+                "Apply an approved settings change plan when mutation support exists."
+            }
+            Self::ApplySourceEdit => {
+                "Apply an approved source edit plan when mutation support exists."
+            }
             Self::AdapterCapabilities => {
                 "Inspect adapter capability availability when the runtime exists."
             }
             Self::Diagnostics => "Return the current site diagnostic operation resource.",
+            Self::MediaChangePlan => "Return the Studio media materialization plan resource.",
+            Self::PublishPlan => "Return the Studio publish plan and apply gate resource.",
+            Self::PreviewReport => "Return the Studio preview report resource.",
+            Self::ReleasePlan => "Return the Studio release plan and health report resource.",
             Self::ResourceCatalog => "List read-only MCP resources and required scopes.",
+            Self::SettingsChangePlan => "Return the Studio settings change plan resource.",
             Self::SiteStatus => "Return the current workspace status operation resource.",
+            Self::SourceEditPlan => "Return the Studio source edit plan resource.",
+            Self::WorkflowVerify => "Return the Studio workflow verification resource.",
         }
     }
 
     fn required_scopes(self) -> Vec<PermissionScope> {
         match self {
+            Self::ApplyMediaChange => vec![PermissionScope::Inspect, PermissionScope::MediaWrite],
+            Self::ApplyPublish => vec![PermissionScope::Inspect, PermissionScope::DeployPublish],
+            Self::ApplySettingsChange | Self::ApplySourceEdit => {
+                vec![PermissionScope::Inspect, PermissionScope::SourceWrite]
+            }
             Self::AdapterCapabilities => ResourceKind::AdapterCapabilities.required_scopes(),
             Self::Diagnostics => ResourceKind::SiteDiagnostics.required_scopes(),
+            Self::MediaChangePlan => ResourceKind::StudioMediaPlan.required_scopes(),
+            Self::PublishPlan => ResourceKind::StudioPublishPlan.required_scopes(),
+            Self::PreviewReport => ResourceKind::StudioPreviewReport.required_scopes(),
+            Self::ReleasePlan => ResourceKind::StudioReleasePlan.required_scopes(),
             Self::ResourceCatalog => vec![PermissionScope::Inspect],
+            Self::SettingsChangePlan => ResourceKind::StudioSettingsPlan.required_scopes(),
             Self::SiteStatus => ResourceKind::WorkspaceStatus.required_scopes(),
+            Self::SourceEditPlan => ResourceKind::StudioContentPlan.required_scopes(),
+            Self::WorkflowVerify => ResourceKind::StudioWorkflowVerify.required_scopes(),
         }
     }
 
-    const fn all() -> [Self; 4] {
+    const fn safety_class(self) -> ToolSafetyClass {
+        match self {
+            Self::AdapterCapabilities
+            | Self::Diagnostics
+            | Self::ResourceCatalog
+            | Self::SiteStatus => ToolSafetyClass::ReadOnly,
+            Self::MediaChangePlan
+            | Self::PublishPlan
+            | Self::PreviewReport
+            | Self::ReleasePlan
+            | Self::SettingsChangePlan
+            | Self::SourceEditPlan
+            | Self::WorkflowVerify => ToolSafetyClass::PlanOnly,
+            Self::ApplyMediaChange
+            | Self::ApplyPublish
+            | Self::ApplySettingsChange
+            | Self::ApplySourceEdit => ToolSafetyClass::ApplyGate,
+        }
+    }
+
+    const fn all() -> [Self; 15] {
         [
             Self::SiteStatus,
             Self::Diagnostics,
             Self::ResourceCatalog,
             Self::AdapterCapabilities,
+            Self::SettingsChangePlan,
+            Self::SourceEditPlan,
+            Self::MediaChangePlan,
+            Self::PreviewReport,
+            Self::ReleasePlan,
+            Self::PublishPlan,
+            Self::WorkflowVerify,
+            Self::ApplySettingsChange,
+            Self::ApplySourceEdit,
+            Self::ApplyMediaChange,
+            Self::ApplyPublish,
         ]
     }
 }
@@ -631,6 +906,10 @@ impl ToolKind {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ToolSafetyClass {
+    /// The tool rejects apply requests until the required plan/apply engine exists.
+    ApplyGate,
+    /// The tool returns a dry-run or plan response and performs no writes.
+    PlanOnly,
     /// The tool performs no source, provider, credential, or output writes.
     ReadOnly,
 }
@@ -655,7 +934,7 @@ impl ToolDescriptor {
             name: kind.name().to_owned(),
             description: kind.description().to_owned(),
             required_scopes: kind.required_scopes(),
-            safety_class: ToolSafetyClass::ReadOnly,
+            safety_class: kind.safety_class(),
         }
     }
 
@@ -819,14 +1098,111 @@ pub fn call_tool(request: &ToolRequest) -> ToolResponse {
             descriptor,
             &resource_for_tool(request, ResourceKind::SiteDiagnostics),
         ),
+        ToolKind::MediaChangePlan => resource_tool_response(
+            descriptor,
+            &resource_for_tool(request, ResourceKind::StudioMediaPlan),
+        ),
+        ToolKind::PublishPlan => resource_tool_response(
+            descriptor,
+            &resource_for_tool(request, ResourceKind::StudioPublishPlan),
+        ),
+        ToolKind::PreviewReport => resource_tool_response(
+            descriptor,
+            &resource_for_tool(request, ResourceKind::StudioPreviewReport),
+        ),
+        ToolKind::ReleasePlan => resource_tool_response(
+            descriptor,
+            &resource_for_tool(request, ResourceKind::StudioReleasePlan),
+        ),
         ToolKind::ResourceCatalog => resource_catalog_tool_response(descriptor),
+        ToolKind::SettingsChangePlan => resource_tool_response(
+            descriptor,
+            &resource_for_tool(request, ResourceKind::StudioSettingsPlan),
+        ),
         ToolKind::SiteStatus => resource_tool_response(
             descriptor,
             &resource_for_tool(request, ResourceKind::WorkspaceStatus),
         ),
+        ToolKind::SourceEditPlan => resource_tool_response(
+            descriptor,
+            &resource_for_tool(request, ResourceKind::StudioContentPlan),
+        ),
+        ToolKind::WorkflowVerify => resource_tool_response(
+            descriptor,
+            &resource_for_tool(request, ResourceKind::StudioWorkflowVerify),
+        ),
+        ToolKind::ApplyMediaChange => {
+            apply_gate_tool_response(descriptor, ApplyToolKind::MediaChange)
+        }
+        ToolKind::ApplyPublish => apply_gate_tool_response(descriptor, ApplyToolKind::Publish),
+        ToolKind::ApplySettingsChange => {
+            apply_gate_tool_response(descriptor, ApplyToolKind::SettingsChange)
+        }
+        ToolKind::ApplySourceEdit => {
+            apply_gate_tool_response(descriptor, ApplyToolKind::SourceEdit)
+        }
     };
 
     audited_tool_response(response, &request.permissions, Vec::new())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ApplyToolKind {
+    MediaChange,
+    Publish,
+    SettingsChange,
+    SourceEdit,
+}
+
+impl ApplyToolKind {
+    const fn tool_kind(self) -> ToolKind {
+        match self {
+            Self::MediaChange => ToolKind::ApplyMediaChange,
+            Self::Publish => ToolKind::ApplyPublish,
+            Self::SettingsChange => ToolKind::ApplySettingsChange,
+            Self::SourceEdit => ToolKind::ApplySourceEdit,
+        }
+    }
+
+    const fn required_plan_tool(self) -> ToolKind {
+        match self {
+            Self::MediaChange => ToolKind::MediaChangePlan,
+            Self::Publish => ToolKind::PublishPlan,
+            Self::SettingsChange => ToolKind::SettingsChangePlan,
+            Self::SourceEdit => ToolKind::SourceEditPlan,
+        }
+    }
+}
+
+fn apply_gate_tool_response(descriptor: ToolDescriptor, kind: ApplyToolKind) -> ToolResponse {
+    let tool_kind = kind.tool_kind();
+    let required_plan_tool = kind.required_plan_tool().name();
+
+    ToolResponse {
+        schema_version: MCP_RESOURCE_SCHEMA_VERSION,
+        tool: descriptor,
+        status: ToolStatus::Unsupported,
+        result: Some(json!({
+            "mutation": "none",
+            "requiredPlanTool": required_plan_tool,
+            "reason": "MCP apply tools are gated until source/provider mutation operations are implemented.",
+        })),
+        diagnostics: DiagnosticReport::from_diagnostics(vec![
+            Diagnostic::new(
+                diagnostic_code("TPM-MCP-APPLY-GATE-UNAVAILABLE"),
+                Severity::Error,
+                format!(
+                    "MCP apply tool '{}' is not available because the shared plan/apply mutation engine is not implemented.",
+                    tool_kind.name()
+                ),
+            )
+            .with_remediation(format!(
+                "Use '{required_plan_tool}' to inspect the plan. Apply support must be implemented in the shared operation core before this MCP tool can mutate source files or providers."
+            )),
+        ]),
+        redaction: RedactionSummary::default(),
+        audit_events: Vec::new(),
+    }
 }
 
 fn resource_for_tool(request: &ToolRequest, kind: ResourceKind) -> ResourceResponse {
@@ -1007,13 +1383,13 @@ fn audited_resource_response(
         action: AuditAction::ResourceRead,
         interface: OperationInterface::Mcp,
         target: response.resource.uri().as_str().to_owned(),
-        safety_class: AuditSafetyClass::ReadOnly,
+        safety_class: AuditSafetyClass::from(response.resource.safety_class),
         outcome: AuditOutcome::from(response.status()),
         required_scopes: response.resource.required_scopes().to_vec(),
         granted_scopes: permissions.scopes().collect(),
         missing_scopes,
-        credential_access: AuditCredentialAccess::None,
-        mutation: AuditMutation::None,
+        credential_access: credential_access_for_resource(response.resource.kind()),
+        mutation: mutation_for_resource(response.resource.kind()),
         redaction: response.redaction(),
     }];
 
@@ -1030,17 +1406,70 @@ fn audited_tool_response(
         action: AuditAction::ToolCall,
         interface: OperationInterface::Mcp,
         target: response.tool.name().to_owned(),
-        safety_class: AuditSafetyClass::ReadOnly,
+        safety_class: AuditSafetyClass::from(response.tool.safety_class),
         outcome: AuditOutcome::from(response.status()),
         required_scopes: response.tool.required_scopes().to_vec(),
         granted_scopes: permissions.scopes().collect(),
         missing_scopes,
-        credential_access: AuditCredentialAccess::None,
-        mutation: AuditMutation::None,
+        credential_access: credential_access_for_tool(response.tool.kind()),
+        mutation: mutation_for_tool(response.tool.kind()),
         redaction: response.redaction,
     }];
 
     response
+}
+
+const fn credential_access_for_resource(kind: ResourceKind) -> AuditCredentialAccess {
+    match kind {
+        ResourceKind::StudioContentPlan
+        | ResourceKind::StudioMediaPlan
+        | ResourceKind::StudioPreviewReport
+        | ResourceKind::StudioPublishPlan
+        | ResourceKind::StudioReleasePlan
+        | ResourceKind::StudioSettingsPlan
+        | ResourceKind::StudioWorkflowVerify => AuditCredentialAccess::ReferenceOnly,
+        ResourceKind::AdapterCapabilities
+        | ResourceKind::MediaImages
+        | ResourceKind::ReleaseInspect
+        | ResourceKind::RoutesRedirects
+        | ResourceKind::SiteDiagnostics
+        | ResourceKind::WorkspaceStatus => AuditCredentialAccess::None,
+    }
+}
+
+const fn credential_access_for_tool(kind: ToolKind) -> AuditCredentialAccess {
+    match kind {
+        ToolKind::ApplyPublish
+        | ToolKind::MediaChangePlan
+        | ToolKind::PublishPlan
+        | ToolKind::PreviewReport
+        | ToolKind::ReleasePlan
+        | ToolKind::SettingsChangePlan
+        | ToolKind::SourceEditPlan
+        | ToolKind::WorkflowVerify => AuditCredentialAccess::ReferenceOnly,
+        ToolKind::ApplyMediaChange
+        | ToolKind::ApplySettingsChange
+        | ToolKind::ApplySourceEdit
+        | ToolKind::AdapterCapabilities
+        | ToolKind::Diagnostics
+        | ToolKind::ResourceCatalog
+        | ToolKind::SiteStatus => AuditCredentialAccess::None,
+    }
+}
+
+const fn mutation_for_resource(kind: ResourceKind) -> AuditMutation {
+    match kind.safety_class() {
+        ResourceSafetyClass::PlanOnly => AuditMutation::Planned,
+        ResourceSafetyClass::ReadOnly => AuditMutation::None,
+    }
+}
+
+const fn mutation_for_tool(kind: ToolKind) -> AuditMutation {
+    match kind.safety_class() {
+        ToolSafetyClass::ApplyGate => AuditMutation::Rejected,
+        ToolSafetyClass::PlanOnly => AuditMutation::Planned,
+        ToolSafetyClass::ReadOnly => AuditMutation::None,
+    }
 }
 
 fn redact_json(value: &mut Value) -> u32 {
@@ -1065,13 +1494,25 @@ fn should_redact(value: &str) -> bool {
 
 const fn scope_label(scope: PermissionScope) -> &'static str {
     match scope {
+        PermissionScope::Admin => "admin",
+        PermissionScope::BuildRun => "build.run",
+        PermissionScope::CredentialTest => "credential.test",
+        PermissionScope::DeployPreview => "deploy.preview",
+        PermissionScope::DeployPublish => "deploy.publish",
+        PermissionScope::DeployRollback => "deploy.rollback",
         PermissionScope::DiagnosticsRead => "diagnostics.read",
+        PermissionScope::ExtensionConfigure => "extension.configure",
         PermissionScope::Inspect => "inspect",
         PermissionScope::MediaRead => "media.read",
+        PermissionScope::MediaWrite => "media.write",
+        PermissionScope::PreviewRun => "preview.run",
         PermissionScope::ProviderStatusRead => "provider.status.read",
         PermissionScope::ReleaseRead => "release.read",
         PermissionScope::RoutesRead => "routes.read",
+        PermissionScope::SourcePropose => "source.propose",
         PermissionScope::SourceRead => "source.read",
+        PermissionScope::SourceWrite => "source.write",
+        PermissionScope::WorkflowTransition => "workflow.transition",
     }
 }
 
@@ -1093,6 +1534,10 @@ mod tests {
     use std::path::PathBuf;
 
     use serde_json::json;
+    use tpm_operations::{
+        OperationInterface, run_studio_preview_plan, run_studio_publish_apply,
+        run_studio_release_plan,
+    };
 
     use super::{
         AuditAction, AuditOutcome, PermissionScope, PermissionSet, ResourceCatalog, ResourceKind,
@@ -1120,6 +1565,13 @@ mod tests {
             vec![
                 ResourceKind::WorkspaceStatus,
                 ResourceKind::SiteDiagnostics,
+                ResourceKind::StudioSettingsPlan,
+                ResourceKind::StudioContentPlan,
+                ResourceKind::StudioMediaPlan,
+                ResourceKind::StudioPreviewReport,
+                ResourceKind::StudioReleasePlan,
+                ResourceKind::StudioPublishPlan,
+                ResourceKind::StudioWorkflowVerify,
                 ResourceKind::ReleaseInspect,
                 ResourceKind::MediaImages,
                 ResourceKind::RoutesRedirects,
@@ -1148,6 +1600,17 @@ mod tests {
                 ToolKind::Diagnostics,
                 ToolKind::ResourceCatalog,
                 ToolKind::AdapterCapabilities,
+                ToolKind::SettingsChangePlan,
+                ToolKind::SourceEditPlan,
+                ToolKind::MediaChangePlan,
+                ToolKind::PreviewReport,
+                ToolKind::ReleasePlan,
+                ToolKind::PublishPlan,
+                ToolKind::WorkflowVerify,
+                ToolKind::ApplySettingsChange,
+                ToolKind::ApplySourceEdit,
+                ToolKind::ApplyMediaChange,
+                ToolKind::ApplyPublish,
             ]
         );
         assert_eq!(catalog.tools()[0].name(), "site_status");
@@ -1219,6 +1682,50 @@ mod tests {
     }
 
     #[test]
+    fn studio_plan_resources_wrap_operation_results() {
+        let workspace = fixture_root();
+        let cases = [
+            (ResourceKind::StudioSettingsPlan, "studio.settings.inspect"),
+            (ResourceKind::StudioContentPlan, "studio.content.editor"),
+            (ResourceKind::StudioMediaPlan, "studio.media.library"),
+            (ResourceKind::StudioPreviewReport, "studio.preview.plan"),
+            (ResourceKind::StudioReleasePlan, "studio.release.plan"),
+            (ResourceKind::StudioPublishPlan, "studio.publish.apply"),
+            (ResourceKind::StudioWorkflowVerify, "studio.workflow.verify"),
+        ];
+
+        for (kind, operation_id) in cases {
+            let response = read_resource(ResourceRequest::new(kind, workspace.clone()));
+
+            assert_eq!(response.status(), ResourceStatus::Available);
+            assert_eq!(response.redaction().redacted_values(), 0);
+
+            let payload = response.payload().expect("payload should be present");
+            assert_eq!(
+                payload.pointer("/operationResult/request/operationId"),
+                Some(&json!(operation_id))
+            );
+            assert_eq!(
+                payload.pointer("/operationResult/request/interface"),
+                Some(&json!("mcp"))
+            );
+            assert_eq!(
+                payload.pointer("/operationResult/payload/kind"),
+                Some(&json!("studio-authoring"))
+            );
+
+            let audit = serde_json::to_value(&response.audit_events()[0])
+                .expect("audit event should serialize");
+            assert_eq!(audit.pointer("/safetyClass"), Some(&json!("plan-only")));
+            assert_eq!(
+                audit.pointer("/credentialAccess"),
+                Some(&json!("reference-only"))
+            );
+            assert_eq!(audit.pointer("/mutation"), Some(&json!("planned")));
+        }
+    }
+
+    #[test]
     fn site_status_tool_wraps_workspace_status_resource() {
         let response = call_tool(&ToolRequest::new(ToolKind::SiteStatus, fixture_root()));
 
@@ -1272,9 +1779,118 @@ mod tests {
             Some(&json!("tpm://resources/workspace/status"))
         );
         assert_eq!(
-            result.pointer("/resources/5/kind"),
+            result.pointer("/resources/12/kind"),
             Some(&json!("adapter-capabilities"))
         );
+    }
+
+    #[test]
+    fn studio_report_tools_wrap_plan_resources() {
+        let workspace = fixture_root();
+        let cases = [
+            (
+                ToolKind::SettingsChangePlan,
+                "studio-settings-plan",
+                "studio.settings.inspect",
+            ),
+            (
+                ToolKind::SourceEditPlan,
+                "studio-content-plan",
+                "studio.content.editor",
+            ),
+            (
+                ToolKind::MediaChangePlan,
+                "studio-media-plan",
+                "studio.media.library",
+            ),
+            (
+                ToolKind::PreviewReport,
+                "studio-preview-report",
+                "studio.preview.plan",
+            ),
+            (
+                ToolKind::ReleasePlan,
+                "studio-release-plan",
+                "studio.release.plan",
+            ),
+            (
+                ToolKind::PublishPlan,
+                "studio-publish-plan",
+                "studio.publish.apply",
+            ),
+            (
+                ToolKind::WorkflowVerify,
+                "studio-workflow-verify",
+                "studio.workflow.verify",
+            ),
+        ];
+
+        for (kind, resource_kind, operation_id) in cases {
+            let response = call_tool(&ToolRequest::new(kind, workspace.clone()));
+
+            assert_eq!(response.status(), ToolStatus::Completed);
+
+            let result = response.result().expect("tool result should be present");
+            assert_eq!(
+                result.pointer("/resource/resource/kind"),
+                Some(&json!(resource_kind))
+            );
+            assert_eq!(
+                result.pointer("/resource/payload/operationResult/request/operationId"),
+                Some(&json!(operation_id))
+            );
+            assert_eq!(
+                result.pointer("/resource/payload/operationResult/request/interface"),
+                Some(&json!("mcp"))
+            );
+
+            let audit = serde_json::to_value(&response.audit_events()[0])
+                .expect("audit event should serialize");
+            assert_eq!(audit.pointer("/safetyClass"), Some(&json!("plan-only")));
+            assert_eq!(audit.pointer("/mutation"), Some(&json!("planned")));
+        }
+    }
+
+    #[test]
+    fn studio_report_resources_match_shared_operation_results_exactly() {
+        let workspace = fixture_root();
+        let cases = [
+            (
+                ResourceKind::StudioPreviewReport,
+                run_studio_preview_plan(workspace.clone(), OperationInterface::Mcp),
+            ),
+            (
+                ResourceKind::StudioReleasePlan,
+                run_studio_release_plan(workspace.clone(), OperationInterface::Mcp),
+            ),
+            (
+                ResourceKind::StudioPublishPlan,
+                run_studio_publish_apply(workspace.clone(), OperationInterface::Mcp),
+            ),
+        ];
+
+        for (kind, operation) in cases {
+            let response = read_resource(ResourceRequest::new(kind, workspace.clone()));
+            let expected = serde_json::to_value(operation).expect("operation should serialize");
+            let payload = response.payload().expect("payload should be present");
+
+            assert_eq!(payload.pointer("/operationResult"), Some(&expected));
+        }
+    }
+
+    #[test]
+    fn publish_plan_tool_exposes_redacted_credential_references_only() {
+        let response = call_tool(&ToolRequest::new(ToolKind::PublishPlan, fixture_root()));
+
+        assert_eq!(response.status(), ToolStatus::Completed);
+        assert_eq!(response.redaction().redacted_values(), 0);
+
+        let serialized = serde_json::to_string(&response).expect("response should serialize");
+
+        assert!(serialized.contains("[redacted]"));
+        assert!(!serialized.contains("desktop-keychain-cloudflare-publish-handle"));
+        assert!(!serialized.contains("token="));
+        assert!(!serialized.contains("api_key="));
     }
 
     #[test]
@@ -1324,6 +1940,34 @@ mod tests {
                 ResourceKind::AdapterCapabilities,
                 &["inspect", "provider.status.read"][..],
             ),
+            (
+                ResourceKind::StudioSettingsPlan,
+                &["inspect", "source.read", "source.propose"][..],
+            ),
+            (
+                ResourceKind::StudioContentPlan,
+                &["inspect", "source.read", "source.propose"][..],
+            ),
+            (
+                ResourceKind::StudioMediaPlan,
+                &["inspect", "media.read"][..],
+            ),
+            (
+                ResourceKind::StudioPreviewReport,
+                &["inspect", "preview.run"][..],
+            ),
+            (
+                ResourceKind::StudioReleasePlan,
+                &["inspect", "release.read", "provider.status.read"][..],
+            ),
+            (
+                ResourceKind::StudioPublishPlan,
+                &["inspect", "release.read", "provider.status.read"][..],
+            ),
+            (
+                ResourceKind::StudioWorkflowVerify,
+                &["inspect", "diagnostics.read", "provider.status.read"][..],
+            ),
         ];
 
         for (kind, labels) in cases {
@@ -1364,6 +2008,133 @@ mod tests {
             response.audit_events()[0].missing_scopes(),
             &[PermissionScope::SourceRead]
         );
+    }
+
+    #[test]
+    fn permission_scope_labels_cover_all_modeled_scopes() {
+        let cases = [
+            (PermissionScope::Admin, "admin"),
+            (PermissionScope::BuildRun, "build.run"),
+            (PermissionScope::CredentialTest, "credential.test"),
+            (PermissionScope::DeployPreview, "deploy.preview"),
+            (PermissionScope::DeployPublish, "deploy.publish"),
+            (PermissionScope::DeployRollback, "deploy.rollback"),
+            (PermissionScope::DiagnosticsRead, "diagnostics.read"),
+            (PermissionScope::ExtensionConfigure, "extension.configure"),
+            (PermissionScope::Inspect, "inspect"),
+            (PermissionScope::MediaRead, "media.read"),
+            (PermissionScope::MediaWrite, "media.write"),
+            (PermissionScope::PreviewRun, "preview.run"),
+            (PermissionScope::ProviderStatusRead, "provider.status.read"),
+            (PermissionScope::ReleaseRead, "release.read"),
+            (PermissionScope::RoutesRead, "routes.read"),
+            (PermissionScope::SourcePropose, "source.propose"),
+            (PermissionScope::SourceRead, "source.read"),
+            (PermissionScope::SourceWrite, "source.write"),
+            (PermissionScope::WorkflowTransition, "workflow.transition"),
+        ];
+
+        for (scope, label) in cases {
+            assert_eq!(super::scope_label(scope), label);
+        }
+    }
+
+    #[test]
+    fn resource_tool_response_preserves_resource_permission_denials() {
+        let tool_descriptor = super::ToolDescriptor::for_kind(ToolKind::SiteStatus);
+        let resource_descriptor =
+            super::ResourceDescriptor::for_kind(ResourceKind::WorkspaceStatus);
+        let denied_resource =
+            super::permission_denied_response(resource_descriptor, &[PermissionScope::SourceRead]);
+
+        let response = super::resource_tool_response(tool_descriptor, &denied_resource);
+
+        assert_eq!(response.status(), ToolStatus::PermissionDenied);
+        assert_eq!(
+            response.diagnostics().errors()[0].code().as_str(),
+            "TPM-MCP-PERMISSION-DENIED"
+        );
+    }
+
+    #[test]
+    fn apply_tools_require_write_or_publish_scopes_before_reaching_gate() {
+        let cases = [
+            (ToolKind::ApplySettingsChange, PermissionScope::SourceWrite),
+            (ToolKind::ApplySourceEdit, PermissionScope::SourceWrite),
+            (ToolKind::ApplyMediaChange, PermissionScope::MediaWrite),
+            (ToolKind::ApplyPublish, PermissionScope::DeployPublish),
+        ];
+
+        for (kind, missing_scope) in cases {
+            let response = call_tool(&ToolRequest::new(kind, fixture_root()));
+
+            assert_eq!(response.status(), ToolStatus::PermissionDenied);
+            assert!(response.result().is_none());
+            assert_eq!(
+                response.audit_events()[0].outcome(),
+                AuditOutcome::PermissionDenied
+            );
+            assert_eq!(
+                response.audit_events()[0].missing_scopes(),
+                &[missing_scope]
+            );
+
+            let audit = serde_json::to_value(&response.audit_events()[0])
+                .expect("audit event should serialize");
+            assert_eq!(audit.pointer("/safetyClass"), Some(&json!("apply-gate")));
+            assert_eq!(audit.pointer("/mutation"), Some(&json!("rejected")));
+        }
+    }
+
+    #[test]
+    fn apply_tools_remain_unsupported_after_permission_until_core_mutations_exist() {
+        let cases = [
+            (
+                ToolKind::ApplySettingsChange,
+                PermissionScope::SourceWrite,
+                "settings_change_plan",
+            ),
+            (
+                ToolKind::ApplySourceEdit,
+                PermissionScope::SourceWrite,
+                "source_edit_plan",
+            ),
+            (
+                ToolKind::ApplyMediaChange,
+                PermissionScope::MediaWrite,
+                "media_change_plan",
+            ),
+            (
+                ToolKind::ApplyPublish,
+                PermissionScope::DeployPublish,
+                "publish_plan",
+            ),
+        ];
+
+        for (kind, apply_scope, plan_tool) in cases {
+            let response = call_tool(
+                &ToolRequest::new(kind, fixture_root())
+                    .with_permissions(PermissionSet::new([PermissionScope::Inspect, apply_scope])),
+            );
+
+            assert_eq!(response.status(), ToolStatus::Unsupported);
+            assert_eq!(
+                response.diagnostics().errors()[0].code().as_str(),
+                "TPM-MCP-APPLY-GATE-UNAVAILABLE"
+            );
+
+            let result = response
+                .result()
+                .expect("unsupported gate explains next step");
+            assert_eq!(result.pointer("/mutation"), Some(&json!("none")));
+            assert_eq!(result.pointer("/requiredPlanTool"), Some(&json!(plan_tool)));
+
+            let audit = serde_json::to_value(&response.audit_events()[0])
+                .expect("audit event should serialize");
+            assert_eq!(audit.pointer("/outcome"), Some(&json!("unsupported")));
+            assert_eq!(audit.pointer("/safetyClass"), Some(&json!("apply-gate")));
+            assert_eq!(audit.pointer("/mutation"), Some(&json!("rejected")));
+        }
     }
 
     #[test]

--- a/docs/RUST_WORKSPACE.md
+++ b/docs/RUST_WORKSPACE.md
@@ -59,23 +59,23 @@ The current ownership model is:
 
 ## Workspace Layout
 
-| Path                              | Purpose                                                                                |
-| --------------------------------- | -------------------------------------------------------------------------------------- |
-| `Cargo.toml`                      | Root Rust workspace, shared package metadata, workspace dependencies, and lint policy. |
-| `Cargo.lock`                      | Locked Rust dependency graph. Commit it because the repo ships binaries/tools.         |
-| `rust-toolchain.toml`             | Pinned Rust toolchain and required components.                                         |
-| `rustfmt.toml`                    | Explicit stable Rust formatting policy.                                                |
-| `deny.toml`                       | Blocking `cargo-deny` supply-chain policy.                                             |
-| `justfile`                        | Local command router over Rust operations and JS/Astro ecosystem adapters.             |
-| `crates/tpm-core/`                | Shared domain primitives such as severity and command exit categories.                 |
-| `crates/tpm-diagnostics/`         | Structured diagnostic codes, diagnostics, and reports.                                 |
-| `crates/tpm-workspace/`           | Workspace and site-instance path modeling.                                             |
-| `crates/tpm-operations/`          | Shared operation request/result envelopes and stable renderers.                        |
-| `crates/tpm-cli/`                 | Additive CLI shell and first command grammar over operation contracts.                 |
-| `crates/tpm-mcp/`                 | Transport-agnostic read-only MCP resource and safety contracts over operation results. |
-| `crates/tpm-xtask/`               | Internal repository automation adapters invoked by focused `just` recipes.             |
-| `tests/fixtures/rust-workspace/`  | Neutral site-like fixture for Rust workspace and future operation tests.               |
-| `tests/fixtures/rust-operations/` | Stable machine-output fixtures for operation envelope compatibility tests.             |
+| Path                              | Purpose                                                                                               |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `Cargo.toml`                      | Root Rust workspace, shared package metadata, workspace dependencies, and lint policy.                |
+| `Cargo.lock`                      | Locked Rust dependency graph. Commit it because the repo ships binaries/tools.                        |
+| `rust-toolchain.toml`             | Pinned Rust toolchain and required components.                                                        |
+| `rustfmt.toml`                    | Explicit stable Rust formatting policy.                                                               |
+| `deny.toml`                       | Blocking `cargo-deny` supply-chain policy.                                                            |
+| `justfile`                        | Local command router over Rust operations and JS/Astro ecosystem adapters.                            |
+| `crates/tpm-core/`                | Shared domain primitives such as severity and command exit categories.                                |
+| `crates/tpm-diagnostics/`         | Structured diagnostic codes, diagnostics, and reports.                                                |
+| `crates/tpm-workspace/`           | Workspace and site-instance path modeling.                                                            |
+| `crates/tpm-operations/`          | Shared operation request/result envelopes and stable renderers.                                       |
+| `crates/tpm-cli/`                 | Additive CLI shell and first command grammar over operation contracts.                                |
+| `crates/tpm-mcp/`                 | Transport-agnostic MCP resource, tool, plan, apply-gate, and safety contracts over operation results. |
+| `crates/tpm-xtask/`               | Internal repository automation adapters invoked by focused `just` recipes.                            |
+| `tests/fixtures/rust-workspace/`  | Neutral site-like fixture for Rust workspace and future operation tests.                              |
+| `tests/fixtures/rust-operations/` | Stable machine-output fixtures for operation envelope compatibility tests.                            |
 
 ## Blocking Rust Gates
 

--- a/docs/STUDIO_MCP_RESOURCE_CONTRACTS.md
+++ b/docs/STUDIO_MCP_RESOURCE_CONTRACTS.md
@@ -1,8 +1,8 @@
 # Studio MCP Resource Contracts
 
-This document records the first implemented Milestone 13 MCP slice. It is the
-implementation handoff for `IRK-197` and a constraint document for later MCP
-tools, permission gates, and write-capable plan/apply work.
+This document records the implemented Milestone 13 MCP contract slice. It is
+the implementation handoff for `IRK-197`, `IRK-199`, `IRK-200`, `IRK-201`,
+`IRK-202`, and `IRK-203`.
 
 Related documents:
 
@@ -14,10 +14,11 @@ Related documents:
 
 ## Purpose
 
-The first MCP implementation is deliberately read-only and transport-agnostic.
-It lives in `crates/tpm-mcp` and models resource descriptors, permission
-defaults, response envelopes, operation-result wrapping, unsupported-resource
-diagnostics, and redaction summaries.
+The MCP implementation is deliberately transport-agnostic. It lives in
+`crates/tpm-mcp` and models resource descriptors, tool descriptors, permission
+defaults, response envelopes, operation-result wrapping, plan-only reports,
+apply gates, unsupported diagnostics, redaction summaries, and deterministic
+response-local audit events.
 
 This crate does not yet run an MCP server. It defines the domain contract that
 a future server can expose over the Model Context Protocol without inventing a
@@ -25,36 +26,58 @@ second diagnostics, workspace, or provider model.
 
 ## Current Tool Catalog
 
-The implemented read-only tool catalog is also transport-agnostic. Tools call
-the same resource functions instead of re-running unrelated MCP-only logic:
+The implemented tool catalog is transport-agnostic. Report and plan tools call
+the same resource functions instead of re-running unrelated MCP-only logic.
+Apply tools are present as explicit gates and reject mutation until shared
+operation-core apply support exists:
 
-| Tool name              | Backing resource or behavior                                                |
-| ---------------------- | --------------------------------------------------------------------------- |
-| `site_status`          | Wraps `tpm://resources/workspace/status`                                    |
-| `site_diagnostics`     | Wraps `tpm://resources/site/diagnostics`                                    |
-| `resource_catalog`     | Returns the current read-only resource descriptors                          |
-| `adapter_capabilities` | Returns the same unsupported capability-registry diagnostic as the resource |
+| Tool name               | Backing resource or behavior                                                |
+| ----------------------- | --------------------------------------------------------------------------- |
+| `site_status`           | Wraps `tpm://resources/workspace/status`                                    |
+| `site_diagnostics`      | Wraps `tpm://resources/site/diagnostics`                                    |
+| `resource_catalog`      | Returns the current resource descriptors                                    |
+| `adapter_capabilities`  | Returns the same unsupported capability-registry diagnostic as the resource |
+| `settings_change_plan`  | Wraps `tpm://resources/studio/settings-plan`                                |
+| `source_edit_plan`      | Wraps `tpm://resources/studio/content-plan`                                 |
+| `media_change_plan`     | Wraps `tpm://resources/studio/media-plan`                                   |
+| `preview_report`        | Wraps `tpm://resources/studio/preview-report`                               |
+| `release_plan`          | Wraps `tpm://resources/studio/release-plan`                                 |
+| `publish_plan`          | Wraps `tpm://resources/studio/publish-plan`                                 |
+| `workflow_verify`       | Wraps `tpm://resources/studio/workflow-verify`                              |
+| `apply_settings_change` | Apply gate; returns unsupported until source mutation apply exists          |
+| `apply_source_edit`     | Apply gate; returns unsupported until source mutation apply exists          |
+| `apply_media_change`    | Apply gate; returns unsupported until media mutation apply exists           |
+| `apply_publish`         | Apply gate; returns unsupported until provider publish apply exists         |
 
-The tool layer is intentionally small. It proves the command shape,
-permission gate, response envelope, redaction propagation, and diagnostics
-mapping for agent-facing inspection. It does not introduce mutating tools,
+The tool layer proves command shape, permission gates, response envelopes,
+redaction propagation, audit semantics, and diagnostics mapping for
+agent-facing inspection and planning. It does not introduce live mutation,
 provider-specific tools, or a second capability model.
 
 ## Current Resource Catalog
 
-The implemented read-only catalog exposes:
+The implemented resource catalog exposes:
 
-| Resource URI                           | Backing operation or status                                          |
-| -------------------------------------- | -------------------------------------------------------------------- |
-| `tpm://resources/workspace/status`     | `workspace.status` operation result                                  |
-| `tpm://resources/site/diagnostics`     | `site.doctor` operation result                                       |
-| `tpm://resources/release/inspect`      | `release.inspect` operation result                                   |
-| `tpm://resources/media/images`         | `media.images` operation result                                      |
-| `tpm://resources/routes/redirects`     | `routes.redirects` operation result                                  |
-| `tpm://resources/adapter-capabilities` | unsupported diagnostic until Milestone 10 capability registry exists |
+| Resource URI                             | Backing operation or status                                          |
+| ---------------------------------------- | -------------------------------------------------------------------- |
+| `tpm://resources/workspace/status`       | `workspace.status` operation result                                  |
+| `tpm://resources/site/diagnostics`       | `site.doctor` operation result                                       |
+| `tpm://resources/studio/settings-plan`   | `studio.settings.inspect` operation result                           |
+| `tpm://resources/studio/content-plan`    | `studio.content.editor` operation result                             |
+| `tpm://resources/studio/media-plan`      | `studio.media.library` operation result                              |
+| `tpm://resources/studio/preview-report`  | `studio.preview.plan` operation result                               |
+| `tpm://resources/studio/release-plan`    | `studio.release.plan` operation result                               |
+| `tpm://resources/studio/publish-plan`    | `studio.publish.apply` operation result as a gated plan              |
+| `tpm://resources/studio/workflow-verify` | `studio.workflow.verify` operation result                            |
+| `tpm://resources/release/inspect`        | `release.inspect` operation result                                   |
+| `tpm://resources/media/images`           | `media.images` operation result                                      |
+| `tpm://resources/routes/redirects`       | `routes.redirects` operation result                                  |
+| `tpm://resources/adapter-capabilities`   | unsupported diagnostic until Milestone 10 capability registry exists |
 
 The resources wrap existing `OperationResult` data with `interface: "mcp"`.
-They do not reformat the operation into a separate MCP-specific model.
+They do not reformat the operation into a separate MCP-specific model. Studio
+plan/report resources expose the shared `StudioAuthoringPayload` operation
+payload with `request.interface: "mcp"`.
 
 ## Permission Defaults
 
@@ -63,7 +86,9 @@ The current permission model is intentionally small and read-only:
 - `inspect`
 - `diagnostics.read`
 - `source.read`
+- `source.propose`
 - `media.read`
+- `preview.run`
 - `routes.read`
 - `release.read`
 - `provider.status.read`
@@ -72,8 +97,22 @@ Missing scopes return a `permission-denied` resource response with
 `TPM-MCP-PERMISSION-DENIED`. The response has no payload and includes an
 actionable remediation.
 
-No write, provider mutation, publish, rollback, credential rotation, or
-destructive scope exists in this slice.
+Additional apply-capable scopes are modeled but not granted by default:
+
+- `source.write`
+- `media.write`
+- `deploy.publish`
+- `deploy.rollback`
+- `build.run`
+- `workflow.transition`
+- `credential.test`
+- `extension.configure`
+- `admin`
+
+No tool currently mutates source, providers, credentials, or generated output.
+Apply tools require the relevant write/publish scope before reaching the apply
+gate, then return `unsupported` with `TPM-MCP-APPLY-GATE-UNAVAILABLE` until
+the shared mutation operation exists.
 
 ## Unsupported Capability Resource
 
@@ -99,17 +138,17 @@ provider scopes, and audit records explicitly.
 
 ## Audit Events
 
-Every current resource read and tool call emits a deterministic read-only audit
-event in the response. These events record:
+Every current resource read and tool call emits a deterministic audit event in
+the response. These events record:
 
 - action: `resource-read` or `tool-call`;
 - interface: `mcp`;
 - target resource URI or tool name;
-- safety class: `read-only`;
+- safety class: `read-only`, `plan-only`, or `apply-gate`;
 - outcome: `completed`, `permission-denied`, or `unsupported`;
 - required, granted, and missing scopes;
-- credential access: `none`;
-- mutation: `none`;
+- credential access: `none` or `reference-only`;
+- mutation: `none`, `planned`, or `rejected`;
 - redaction summary.
 
 This is the current safety envelope, not the final persisted audit log. The
@@ -158,16 +197,27 @@ The current tool tests cover:
 - `resource_catalog` returning resource descriptors;
 - permission-denied behavior for tools;
 - adapter-capability tool fallback while the capability registry is missing;
-- read-only audit events for completed and permission-denied tool calls.
+- Studio report tools wrapping shared Studio operation resources;
+- exact operation-result parity for Studio preview, release, and publish plan
+  resources;
+- apply tools denying missing write/publish scopes before any mutation path;
+- apply tools returning unsupported after permission until operation-core
+  mutation exists;
+- credential secret handles staying absent from serialized MCP publish-plan
+  responses;
+- audit events for read-only, plan-only, permission-denied, unsupported, and
+  apply-gated responses.
 
 ## Blocked Follow-Up
 
 `IRK-199` has an initial read-only tool slice for status, diagnostics,
-resource discovery, and adapter-capability fallback. Full provider-aware
-adapter-capability inspection remains blocked on `IRK-181`.
+resource discovery, and adapter-capability fallback.
 
-`IRK-201` can build on the permission and redaction primitives after the
-read-only resource skeleton exists. This slice now covers read-only permission
-gates, redaction summaries, and deterministic response-local audit events. The
-full credential/audit integration still depends on the Milestone 10 identity
-and credential boundaries.
+`IRK-201` now covers permission gates, redaction summaries, and deterministic
+response-local audit events for the current MCP contract surface. The full
+credential/audit integration for persisted audit storage and live providers
+belongs to future provider/runtime work.
+
+`IRK-202` intentionally stops at apply gates. Real source writes, provider
+publishes, rollbacks, and credential tests must be implemented in the shared
+operation core first, then exposed through MCP as thin adapters.

--- a/docs/STUDIO_MCP_SAFETY_MODEL.md
+++ b/docs/STUDIO_MCP_SAFETY_MODEL.md
@@ -52,10 +52,11 @@ Read-only resources should expose structured snapshots:
 Resources should be stable enough for agents to reason over without scraping
 HTML or logs.
 
-The first implemented resource and read-only tool skeleton is documented in
+The implemented resource, tool, plan, and apply-gate contract is documented in
 [`STUDIO_MCP_RESOURCE_CONTRACTS.md`](./STUDIO_MCP_RESOURCE_CONTRACTS.md). It is
-transport-agnostic, read-only, and wraps existing Rust operation results instead
-of inventing an MCP-only diagnostics or workspace model.
+transport-agnostic and wraps existing Rust operation results instead of
+inventing an MCP-only diagnostics, workspace, preview, release, or publish
+model.
 
 ## Tool Classes
 
@@ -71,6 +72,18 @@ of inventing an MCP-only diagnostics or workspace model.
 
 Tools should call headless core operations. They should not edit files or call
 providers directly.
+
+Current implementation status:
+
+- inspection and report tools are available for workspace status, site
+  diagnostics, resource discovery, adapter-capability fallback, Studio
+  settings/content/media plans, preview reports, release plans, publish plans,
+  and workflow verification;
+- plan tools are `plan-only` and return shared operation envelopes with
+  `request.interface: "mcp"`;
+- apply tools exist only as gates. They require write/publish scopes, then
+  return `unsupported` until source/provider mutation operations exist in the
+  shared core.
 
 ## Permission Scopes
 
@@ -96,6 +109,10 @@ MCP scopes should map to platform scopes:
 
 Scope absence should omit tools where possible and return explicit diagnostics
 where a caller attempts a forbidden action.
+
+The first implemented permission set grants safe inspect/report/plan scopes by
+default and withholds write/publish scopes. The withheld scopes are still
+modeled so apply requests can fail before any mutation path is considered.
 
 ## Plan And Apply
 
@@ -123,6 +140,11 @@ Apply request:
 
 Apply should reject stale plans, changed source snapshots, missing scopes,
 blocking diagnostics, and missing credentials.
+
+In the current transport-agnostic crate, apply tools stop earlier than this:
+they reject missing write/publish scopes, and even when those scopes are
+present they return `TPM-MCP-APPLY-GATE-UNAVAILABLE`. This is intentional. MCP
+must not become the first implementation of source/provider mutation semantics.
 
 ## Tool Result Schema
 
@@ -197,6 +219,19 @@ Later implementation should add fixtures for:
 
 Tests should assert that MCP results match the same diagnostic and operation
 schemas used by CLI and GUI.
+
+Current Milestone 13 tests cover the implemented subset:
+
+- resource and tool catalog order;
+- exact wrapping of shared Studio preview, release, and publish operation
+  results;
+- default read/report/plan access;
+- missing-scope permission denial;
+- apply-gate unsupported responses after explicit write/publish scopes;
+- adapter-capability unsupported diagnostics;
+- secret-handle redaction and absence from serialized MCP responses;
+- deterministic audit events for read-only, plan-only, permission-denied,
+  unsupported, and rejected apply-gate paths.
 
 ## Handoff
 


### PR DESCRIPTION
Implemented the MCP automation/safety slice in crates/tpm-mcp/src/librs (line 42): Studio plan/report resources, matching MCP tools, explicit permission scopes, audit/redaction behavior, and non-mutating apply gates. The apply tools now require write/publish scopes first, then intentionally return TPM-MCP-APPLY-GATE-UNAVAILABLE until shared operation-core mutation support exists.